### PR TITLE
v1.0.0-alpha.11の変更に対応

### DIFF
--- a/deprecated_border_style.mjs
+++ b/deprecated_border_style.mjs
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2024 DenkiYagi Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import xpath from 'xpath'
+
+function update(attribute) {
+    if (!attribute) return;
+    if (!xpath.isAttribute(attribute)) return;
+
+    const value = attribute.textContent;
+
+    attribute.textContent = value.replace(/dotted/gi, "dot").replace(/dashed/gi, "dash")
+}
+
+/**
+ * `dotted`, `dashed` を `dot`, `dash` に変換します。
+ * @param {Document} doc 
+ * @param {string} expression
+ */
+function updateAttributeValue(doc, expression) {
+    const result = xpath.select(expression, doc);
+    if (xpath.isArrayOfNodes(result)) {
+        for (let i = 0; i < result.length; i++) {
+            update(result[i]);
+        }
+    } else {
+        update(result);
+    }
+}
+
+/**
+ * v1.0.0-alpha.11での `borderStyle` の `dotted`, `dashed` 廃止に伴い、 `dot`, `dash` に置き換えます。
+ * @param {Document} doc 
+ */
+export function migrate(doc) {
+    updateAttributeValue(doc, "//@borderStyle");
+    updateAttributeValue(doc, "//@borderTopStyle");
+    updateAttributeValue(doc, "//@borderRightStyle");
+    updateAttributeValue(doc, "//@borderBottomStyle");
+    updateAttributeValue(doc, "//@borderLeftStyle");
+
+    updateAttributeValue(doc, "//@outerBorderStyle");
+    updateAttributeValue(doc, "//@outerBorderTopStyle");
+    updateAttributeValue(doc, "//@outerBorderRightStyle");
+    updateAttributeValue(doc, "//@outerBorderBottomStyle");
+    updateAttributeValue(doc, "//@outerBorderLeftStyle");
+}

--- a/deprecated_border_style.mjs
+++ b/deprecated_border_style.mjs
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 DenkiYagi Inc.
+ * Copyright 2023 DenkiYagi Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deprecated_border_style.test.js
+++ b/deprecated_border_style.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 DenkiYagi Inc.
+ * Copyright 2023 DenkiYagi Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deprecated_border_style.test.js
+++ b/deprecated_border_style.test.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2024 DenkiYagi Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as deprecated_border_style from './deprecated_border_style.mjs';
+import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
+
+test.each([
+    {input: '<LinearLayout borderStyle="dashed"/>', expected: '<LinearLayout borderStyle="dash"/>'},
+    {input: '<LinearLayout borderStyle="Dashed"/>', expected: '<LinearLayout borderStyle="dash"/>'},
+
+    {input: '<LinearLayout borderStyle="dotted"/>', expected: '<LinearLayout borderStyle="dot"/>'},
+    {input: '<LinearLayout borderStyle="Dotted"/>', expected: '<LinearLayout borderStyle="dot"/>'},
+
+    {input: '<LinearLayout borderStyle="solid"/>',  expected: '<LinearLayout borderStyle="solid"/>'},
+    {input: '<LinearLayout borderStyle="SOLID"/>',  expected: '<LinearLayout borderStyle="SOLID"/>'},
+
+    {input: '<LinearLayout borderStyle="solid dashed"/>', expected: '<LinearLayout borderStyle="solid dash"/>'},
+    {input: '<LinearLayout borderStyle="SOLID dashed"/>', expected: '<LinearLayout borderStyle="SOLID dash"/>'},
+
+    {input: '<LinearLayout borderStyle="dashed dotted dotted dashed"/>', expected: '<LinearLayout borderStyle="dash dot dot dash"/>'},
+
+    {input: '<LayoutBody><Grid borderStyle="dashed"/><Grid borderStyle="dotted"/></LayoutBody>',
+        expected: '<LayoutBody><Grid borderStyle="dash"/><Grid borderStyle="dot"/></LayoutBody>'},
+])('属性値を更新できる: "$input"', ({input, expected}) => {
+    const doc = new DOMParser().parseFromString(input);
+    deprecated_border_style.migrate(doc);
+    const actual = new XMLSerializer().serializeToString(doc);
+    expect(actual).toStrictEqual(expected);
+});

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@
 import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
 import * as fs from 'fs/promises';
 import * as direction_attribute from './direction_attribute.mjs';
+import * as deprecated_border_style from './deprecated_border_style.mjs';
 import * as path from 'path';
 import * as msgpack from '@msgpack/msgpack';
 import * as util from 'util';
@@ -25,6 +26,7 @@ function migrate(inputLayoutXml) {
     const doc = new DOMParser().parseFromString(inputLayoutXml, 'text/xml');
     
     direction_attribute.migrate(doc);
+    deprecated_border_style.migrate(doc);
 
     const outputLayoutXml = new XMLSerializer().serializeToString(doc);
     return outputLayoutXml;


### PR DESCRIPTION
- borderStyleの廃止された `dotted`, `dashed` を `dot`, `dash` に変換