### PR TITLE
alpha.13->v1.0 マイグレーション処理の各種修正

### DIFF
--- a/apply_schema.mjs
+++ b/apply_schema.mjs
@@ -1,0 +1,87 @@
+// @ts-check
+
+import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
+
+/**
+ * XMLタイプ別のスキーマURL
+ */
+const SCHEMA_URLS = {
+    layout: 'https://schemas.yagisan.app/2025.1/layout.xsd',
+    style: 'https://schemas.yagisan.app/2025.1/style.xsd'
+};
+
+/**
+ * 要素の属性リストの先頭に新しい属性を挿入する
+ *
+ * @param {Element} element 変更するXML要素
+ * @param {Record<string, string>} newAttributes 属性名をkey、属性値をvalueとするオブジェクト
+ */
+function unshiftAttributes(element, newAttributes) {
+    const existingAttrs = [];
+    if (element.attributes) {
+        for (let i = 0; i < element.attributes.length; i++) {
+            const attr = element.attributes[i];
+            existingAttrs.push({ name: attr.name, value: attr.value });
+        }
+    }
+
+    while (element.attributes.length > 0) {
+        element.removeAttribute(element.attributes[0].name);
+    }
+
+    Object.entries(newAttributes).forEach(([name, value]) => {
+        element.setAttribute(name, value);
+    });
+
+    existingAttrs.forEach(attr => {
+        element.setAttribute(attr.name, attr.value);
+    });
+}
+
+/**
+ * XMLルート要素にスキーマ関連の属性を追加する
+ *
+ * @param {string} xml XML文字列
+ * @param {string} schemaUrl 追加するスキーマURL
+ * @returns {string} スキーマ属性が追加された新しいXML
+ */
+function addSchemaToXml(xml, schemaUrl) {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(xml, 'text/xml');
+
+    const rootElement = doc.documentElement;
+    if (!rootElement || rootElement.tagName === 'parsererror') {
+        throw new Error(`XML parsing error: Invalid XML format`);
+    }
+
+    // スキーマ属性を先頭に挿入
+    unshiftAttributes(rootElement, {
+        'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+        'xsi:noNamespaceSchemaLocation': schemaUrl
+    });
+
+    return new XMLSerializer().serializeToString(doc);
+}
+
+/**
+ * YrtRoot構造内のすべてのXMLに in-place でスキーマ属性を適用する
+ *
+ * @param {import('./yrt_format.js').YrtRoot} yrtRoot YRTルート構造
+ * @returns {import('./yrt_format.js').YrtRoot} 変更されたYrtRoot
+ */
+export function migrate(yrtRoot) {
+    const yrtBody = yrtRoot[2];
+    const layouts = yrtBody.l;
+
+    // すべてのレイアウトXMLにスキーマを適用
+    for (let i = 0; i < layouts.length; i++) {
+        layouts[i][1] = addSchemaToXml(layouts[i][1], SCHEMA_URLS.layout);
+    }
+
+    // スタイルXMLが存在する場合はスキーマを適用
+    if (yrtBody.s) {
+        yrtBody.s = addSchemaToXml(yrtBody.s, SCHEMA_URLS.style);
+    }
+
+    return yrtRoot;
+}

--- a/apply_schema.test.js
+++ b/apply_schema.test.js
@@ -1,0 +1,47 @@
+import { migrate } from "./apply_schema.mjs";
+import { toYrtRoot, fromYrtRoot } from "./utils.js";
+
+describe("XMLスキーマ指定用の属性追加 (apply_schema)", () => {
+    it("レイアウトXMLにスキーマ属性を追加する", () => {
+        const input = '<LinearLayout></LinearLayout>';
+        const yrtRoot = toYrtRoot({ layouts: [input] });
+        const migrated = migrate(yrtRoot);
+        const { layouts } = fromYrtRoot(migrated);
+        const migratedXml = layouts[0];
+
+        expect(migratedXml).toContain('xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"');
+        expect(migratedXml).toContain('xsi:noNamespaceSchemaLocation="https://schemas.yagisan.app/2025.1/layout.xsd"');
+    });
+
+    it("スタイルXMLにスキーマ属性を追加する", () => {
+        const input = '<Style></Style>';
+        const yrtRoot = toYrtRoot({ layouts: [], styleXml: input });
+        const migrated = migrate(yrtRoot);
+        const { styleXml } = fromYrtRoot(migrated);
+
+        expect(styleXml).toContain('xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"');
+        expect(styleXml).toContain('xsi:noNamespaceSchemaLocation="https://schemas.yagisan.app/2025.1/style.xsd"');
+    });
+
+    it("複数のレイアウトにスキーマ属性を追加する", () => {
+        const layout1 = '<LinearLayout><Text /></LinearLayout>';
+        const layout2 = '<StackLayout><Text x="0" y="0" width="100" /></StackLayout>';
+        const yrtRoot = toYrtRoot({ layouts: [layout1, layout2] });
+        const migrated = migrate(yrtRoot);
+        const { layouts } = fromYrtRoot(migrated);
+
+        expect(layouts[0]).toContain('https://schemas.yagisan.app/2025.1/layout.xsd');
+        expect(layouts[1]).toContain('https://schemas.yagisan.app/2025.1/layout.xsd');
+    });
+
+    it("同一YRTルート内のレイアウトとスタイルXMLの両方を処理する", () => {
+        const layoutXml = '<LinearLayout></LinearLayout>';
+        const styleXml = '<Style></Style>';
+        const yrtRoot = toYrtRoot({ layouts: [layoutXml], styleXml });
+        const migrated = migrate(yrtRoot);
+        const { layouts, styleXml: migratedStyle } = fromYrtRoot(migrated);
+
+        expect(layouts[0]).toContain('https://schemas.yagisan.app/2025.1/layout.xsd');
+        expect(migratedStyle).toContain('https://schemas.yagisan.app/2025.1/style.xsd');
+    });
+});

--- a/binding_required_warn.mjs
+++ b/binding_required_warn.mjs
@@ -20,12 +20,12 @@ export function migrate(yrtRoot) {
         for (const table of tables) {
             const xpath = getXPath(table);
             // items属性
-            const items = table.getAttribute("items");
+            const items = table.getAttribute("items")?.trim();
             if (items && !/^\$\{[^}]+\}$/.test(items)) {
                 console.warn(`items属性はバインド変数で指定してください: ${items} (${xpath})`);
             }
             // breakCondition属性
-            const breakCond = table.getAttribute("breakCondition");
+            const breakCond = table.getAttribute("breakCondition")?.trim();
             if (breakCond && !/^\$\{[^}]+\}$/.test(breakCond)) {
                 console.warn(`breakCondition属性はバインド変数で指定してください: ${breakCond} (${xpath})`);
             }

--- a/binding_required_warn.test.js
+++ b/binding_required_warn.test.js
@@ -45,4 +45,20 @@ describe("バインド変数必須化マイグレーション (bindingRequiredWa
         migrate(yrtRoot);
         expect(warnSpy).not.toHaveBeenCalled();
     });
+
+    it("items/breakCondition属性値に前後空白があっても正しく判定される", () => {
+        const xml = '<Table items="  ${foo}  " breakCondition="  true  " />';
+        const yrtRoot = toYrtRoot({ layouts: [xml] });
+        migrate(yrtRoot);
+        // itemsはバインド変数なので警告なし、breakConditionはリテラルなので警告
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("breakCondition属性はバインド変数で指定してください"));
+    });
+
+    it("items属性値が空白のみの場合は警告しない", () => {
+        const xml = '<Table items="   " />';
+        const yrtRoot = toYrtRoot({ layouts: [xml] });
+        migrate(yrtRoot);
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
 });

--- a/borderstyle_dasharray_to_colon.mjs
+++ b/borderstyle_dasharray_to_colon.mjs
@@ -28,7 +28,7 @@ function convertDasharray(doc) {
         const el = elements[i];
         const val = el.getAttribute && el.getAttribute("borderStyle");
         if (typeof val === "string") {
-            const m = val.match(/^\s*dasharray\((.*)\)\s*$/);
+            const m = val.match(/^\s*dasharray\((.*)\)\s*$/i);
             if (m) {
                 // dasharray(...) の中身を安全に抽出
                 const inner = m[1];

--- a/borderstyle_dasharray_to_colon.mjs
+++ b/borderstyle_dasharray_to_colon.mjs
@@ -28,7 +28,7 @@ function convertDasharray(doc) {
         const el = elements[i];
         const val = el.getAttribute && el.getAttribute("borderStyle");
         if (typeof val === "string") {
-            const m = val.match(/^dasharray\((.*)\)$/);
+            const m = val.match(/^\s*dasharray\((.*)\)\s*$/);
             if (m) {
                 // dasharray(...) の中身を安全に抽出
                 const inner = m[1];

--- a/borderstyle_dasharray_to_colon.test.js
+++ b/borderstyle_dasharray_to_colon.test.js
@@ -43,4 +43,13 @@ describe("borderStyle属性 dasharray()→コロン区切り変換マイグレ�
         const doc = new DOMParser().parseFromString(layouts[0], "text/xml");
         expect(doc.documentElement.hasAttribute("borderStyle")).toBe(false);
     });
+
+    it("dasharray()の前後に空白があっても正しく変換される", () => {
+        const xml = '<Rectangle borderStyle="   dasharray( 1 , 2 )   " />';
+        const yrtRoot = toYrtRoot({ layouts: [xml] });
+        const migrated = migrate(yrtRoot);
+        const { layouts } = fromYrtRoot(migrated);
+        const doc = new DOMParser().parseFromString(layouts[0], "text/xml");
+        expect(doc.documentElement.getAttribute("borderStyle")).toBe(" 1:2 ");
+    });
 });

--- a/borderstyle_dasharray_to_colon.test.js
+++ b/borderstyle_dasharray_to_colon.test.js
@@ -52,4 +52,12 @@ describe("borderStyle属性 dasharray()→コロン区切り変換マイグレ�
         const doc = new DOMParser().parseFromString(layouts[0], "text/xml");
         expect(doc.documentElement.getAttribute("borderStyle")).toBe(" 1:2 ");
     });
+    it("dasharrayが大文字・小文字混在でも変換される", () => {
+        const xml = '<Rectangle borderStyle="DaShArRaY(7,8)" />';
+        const yrtRoot = toYrtRoot({ layouts: [xml] });
+        const migrated = migrate(yrtRoot);
+        const { layouts } = fromYrtRoot(migrated);
+        const doc = new DOMParser().parseFromString(layouts[0], "text/xml");
+        expect(doc.documentElement.getAttribute("borderStyle")).toBe("7:8");
+    });
 });

--- a/color_notation_illustrator.mjs
+++ b/color_notation_illustrator.mjs
@@ -5,6 +5,8 @@ const COLOR_ATTRS = [
     "borderColor",
     "outerBorderColor",
     "backgroundColor",
+    "headerBackgroundColor",
+    "footerBackgroundColor",
 ];
 
 function toK(val) {

--- a/color_notation_illustrator.mjs
+++ b/color_notation_illustrator.mjs
@@ -10,7 +10,7 @@ const COLOR_ATTRS = [
 ];
 
 function toK(val) {
-    const m = val.match(/^grayscale\(\s*(\d*\.?\d+)\s*\)$/);
+    const m = val.match(/^grayscale\(\s*(\d*\.?\d+)\s*\)$/i);
     if (!m) return null;
     // 0.0→100, 1.0→0
     const v = Math.round((1 - parseFloat(m[1])) * 100);
@@ -18,7 +18,7 @@ function toK(val) {
 }
 
 function toRGB(val) {
-    const m = val.match(/^rgb\(\s*(\d*\.?\d+)\s*,\s*(\d*\.?\d+)\s*,\s*(\d*\.?\d+)\s*\)$/);
+    const m = val.match(/^rgb\(\s*(\d*\.?\d+)\s*,\s*(\d*\.?\d+)\s*,\s*(\d*\.?\d+)\s*\)$/i);
     if (!m) return null;
     const r = Math.round(parseFloat(m[1]) * 100);
     const g = Math.round(parseFloat(m[2]) * 100);
@@ -27,7 +27,7 @@ function toRGB(val) {
 }
 
 function toCMYK(val) {
-    const m = val.match(/^cmyk\(\s*(\d*\.?\d+)\s*,\s*(\d*\.?\d+)\s*,\s*(\d*\.?\d+)\s*,\s*(\d*\.?\d+)\s*\)$/);
+    const m = val.match(/^cmyk\(\s*(\d*\.?\d+)\s*,\s*(\d*\.?\d+)\s*,\s*(\d*\.?\d+)\s*,\s*(\d*\.?\d+)\s*\)$/i);
     if (!m) return null;
     const c = Math.round(parseFloat(m[1]) * 100);
     const m_ = Math.round(parseFloat(m[2]) * 100);

--- a/color_notation_illustrator.mjs
+++ b/color_notation_illustrator.mjs
@@ -10,7 +10,7 @@ const COLOR_ATTRS = [
 ];
 
 function toK(val) {
-    const m = val.match(/^grayscale\((\d*\.?\d+)\)$/);
+    const m = val.match(/^grayscale\(\s*(\d*\.?\d+)\s*\)$/);
     if (!m) return null;
     // 0.0→100, 1.0→0
     const v = Math.round((1 - parseFloat(m[1])) * 100);
@@ -18,7 +18,7 @@ function toK(val) {
 }
 
 function toRGB(val) {
-    const m = val.match(/^rgb\((\d*\.?\d+),(\d*\.?\d+),(\d*\.?\d+)\)$/);
+    const m = val.match(/^rgb\(\s*(\d*\.?\d+)\s*,\s*(\d*\.?\d+)\s*,\s*(\d*\.?\d+)\s*\)$/);
     if (!m) return null;
     const r = Math.round(parseFloat(m[1]) * 100);
     const g = Math.round(parseFloat(m[2]) * 100);
@@ -27,7 +27,7 @@ function toRGB(val) {
 }
 
 function toCMYK(val) {
-    const m = val.match(/^cmyk\((\d*\.?\d+),(\d*\.?\d+),(\d*\.?\d+),(\d*\.?\d+)\)$/);
+    const m = val.match(/^cmyk\(\s*(\d*\.?\d+)\s*,\s*(\d*\.?\d+)\s*,\s*(\d*\.?\d+)\s*,\s*(\d*\.?\d+)\s*\)$/);
     if (!m) return null;
     const c = Math.round(parseFloat(m[1]) * 100);
     const m_ = Math.round(parseFloat(m[2]) * 100);
@@ -40,7 +40,7 @@ function migrateNode(node) {
     if (node.nodeType !== 1) return;
     for (const attr of COLOR_ATTRS) {
         if (node.hasAttribute(attr)) {
-            const val = node.getAttribute(attr);
+            const val = node.getAttribute(attr).trim();
             let newVal = null;
             newVal = toK(val) || toRGB(val) || toCMYK(val);
             if (newVal) node.setAttribute(attr, newVal);

--- a/color_notation_illustrator.test.js
+++ b/color_notation_illustrator.test.js
@@ -41,6 +41,16 @@ describe("カラー記法のIllustrator寄り変換マイグレーション", ()
             const out = new XMLSerializer().serializeToString(doc.documentElement);
             expect(out).toContain('color="K88"');
         });
+
+        it("color='grayscale( 0.5 )'（空白あり）→ color='K50'", () => {
+            const xml = `<Text color="grayscale(  0.5  )"/>`;
+            const yrtRoot = toYrtRoot({ layouts: [xml] });
+            const migrated = migrate(yrtRoot);
+            const { layouts } = fromYrtRoot(migrated);
+            const doc = new DOMParser().parseFromString(layouts[0], "text/xml");
+            const out = new XMLSerializer().serializeToString(doc.documentElement);
+            expect(out).toContain('color="K50"');
+        });
     });
     describe("rgb → RxGxBx記法", () => {
         it("color='rgb(0.0,0.5,1.0)' → color='R0G50B100'", () => {
@@ -52,10 +62,30 @@ describe("カラー記法のIllustrator寄り変換マイグレーション", ()
             const out = new XMLSerializer().serializeToString(doc.documentElement);
             expect(out).toContain('color="R0G50B100"');
         });
+
+        it("color='rgb( 0.0 , 0.5 , 1.0 )'（空白あり）→ color='R0G50B100'", () => {
+            const xml = `<Text color="rgb( 0.0 , 0.5 , 1.0 )"/>`;
+            const yrtRoot = toYrtRoot({ layouts: [xml] });
+            const migrated = migrate(yrtRoot);
+            const { layouts } = fromYrtRoot(migrated);
+            const doc = new DOMParser().parseFromString(layouts[0], "text/xml");
+            const out = new XMLSerializer().serializeToString(doc.documentElement);
+            expect(out).toContain('color="R0G50B100"');
+        });
     });
     describe("cmyk → CxMxYxKx記法", () => {
         it("color='cmyk(0.0,0.5,1.0,0.25)' → color='C0M50Y100K25'", () => {
             const xml = `<Text color="cmyk(0.0,0.5,1.0,0.25)"/>`;
+            const yrtRoot = toYrtRoot({ layouts: [xml] });
+            const migrated = migrate(yrtRoot);
+            const { layouts } = fromYrtRoot(migrated);
+            const doc = new DOMParser().parseFromString(layouts[0], "text/xml");
+            const out = new XMLSerializer().serializeToString(doc.documentElement);
+            expect(out).toContain('color="C0M50Y100K25"');
+        });
+
+        it("color='cmyk( 0.0 , 0.5 , 1.0 , 0.25 )'（空白あり）→ color='C0M50Y100K25'", () => {
+            const xml = `<Text color="cmyk( 0.0 , 0.5 , 1.0 , 0.25 )"/>`;
             const yrtRoot = toYrtRoot({ layouts: [xml] });
             const migrated = migrate(yrtRoot);
             const { layouts } = fromYrtRoot(migrated);

--- a/color_notation_illustrator.test.js
+++ b/color_notation_illustrator.test.js
@@ -51,6 +51,15 @@ describe("カラー記法のIllustrator寄り変換マイグレーション", ()
             const out = new XMLSerializer().serializeToString(doc.documentElement);
             expect(out).toContain('color="K50"');
         });
+        it("color='GrAyScAlE(0.5)'（大文字・小文字混在）→ color='K50'", () => {
+            const xml = `<Text color="GrAyScAlE(0.5)"/>`;
+            const yrtRoot = toYrtRoot({ layouts: [xml] });
+            const migrated = migrate(yrtRoot);
+            const { layouts } = fromYrtRoot(migrated);
+            const doc = new DOMParser().parseFromString(layouts[0], "text/xml");
+            const out = new XMLSerializer().serializeToString(doc.documentElement);
+            expect(out).toContain('color="K50"');
+        });
     });
     describe("rgb → RxGxBx記法", () => {
         it("color='rgb(0.0,0.5,1.0)' → color='R0G50B100'", () => {
@@ -72,6 +81,15 @@ describe("カラー記法のIllustrator寄り変換マイグレーション", ()
             const out = new XMLSerializer().serializeToString(doc.documentElement);
             expect(out).toContain('color="R0G50B100"');
         });
+        it("color='RgB(0.0,0.5,1.0)'（大文字・小文字混在）→ color='R0G50B100'", () => {
+            const xml = `<Text color="RgB(0.0,0.5,1.0)"/>`;
+            const yrtRoot = toYrtRoot({ layouts: [xml] });
+            const migrated = migrate(yrtRoot);
+            const { layouts } = fromYrtRoot(migrated);
+            const doc = new DOMParser().parseFromString(layouts[0], "text/xml");
+            const out = new XMLSerializer().serializeToString(doc.documentElement);
+            expect(out).toContain('color="R0G50B100"');
+        });
     });
     describe("cmyk → CxMxYxKx記法", () => {
         it("color='cmyk(0.0,0.5,1.0,0.25)' → color='C0M50Y100K25'", () => {
@@ -86,6 +104,15 @@ describe("カラー記法のIllustrator寄り変換マイグレーション", ()
 
         it("color='cmyk( 0.0 , 0.5 , 1.0 , 0.25 )'（空白あり）→ color='C0M50Y100K25'", () => {
             const xml = `<Text color="cmyk( 0.0 , 0.5 , 1.0 , 0.25 )"/>`;
+            const yrtRoot = toYrtRoot({ layouts: [xml] });
+            const migrated = migrate(yrtRoot);
+            const { layouts } = fromYrtRoot(migrated);
+            const doc = new DOMParser().parseFromString(layouts[0], "text/xml");
+            const out = new XMLSerializer().serializeToString(doc.documentElement);
+            expect(out).toContain('color="C0M50Y100K25"');
+        });
+        it("color='CmYk(0.0,0.5,1.0,0.25)'（大文字・小文字混在）→ color='C0M50Y100K25'", () => {
+            const xml = `<Text color="CmYk(0.0,0.5,1.0,0.25)"/>`;
             const yrtRoot = toYrtRoot({ layouts: [xml] });
             const migrated = migrate(yrtRoot);
             const { layouts } = fromYrtRoot(migrated);

--- a/color_notation_illustrator.test.js
+++ b/color_notation_illustrator.test.js
@@ -75,7 +75,7 @@ describe("カラー記法のIllustrator寄り変換マイグレーション", ()
             expect(out).toContain('color="K80"');
         });
     });
-    describe("全属性網羅", () => {
+    describe("全属性網羅（一般）", () => {
         it("borderColor, outerBorderColor, backgroundColorも変換", () => {
             const xml = `<Rectangle borderColor="grayscale(0.5)" outerBorderColor="rgb(1.0,0,0)" backgroundColor="cmyk(0,0,0,1.0)"/>`;
             const yrtRoot = toYrtRoot({ layouts: [xml] });
@@ -86,6 +86,19 @@ describe("カラー記法のIllustrator寄り変換マイグレーション", ()
             expect(out).toContain('borderColor="K50"');
             expect(out).toContain('outerBorderColor="R100G0B0"');
             expect(out).toContain('backgroundColor="C0M0Y0K100"');
+        });
+    });
+
+    describe("全属性網羅（Table系特殊）", () => {
+        it("headerBackgroundColor, footerBackgroundColorも変換", () => {
+            const xml = `<Table headerBackgroundColor="grayscale(0.2)" footerBackgroundColor="rgb(0.1,0.2,0.3)"/>`;
+            const yrtRoot = toYrtRoot({ layouts: [xml] });
+            const migrated = migrate(yrtRoot);
+            const { layouts } = fromYrtRoot(migrated);
+            const doc = new DOMParser().parseFromString(layouts[0], "text/xml");
+            const out = new XMLSerializer().serializeToString(doc.documentElement);
+            expect(out).toContain('headerBackgroundColor="K80"');
+            expect(out).toContain('footerBackgroundColor="R10G20B30"');
         });
     });
 });

--- a/foreach_hidden_to_logic.mjs
+++ b/foreach_hidden_to_logic.mjs
@@ -8,9 +8,19 @@ function isBindingVariable(val) {
 
 function migrateElement(el, warnings) {
     if (!el || !el.getAttribute) return;
-    const foreach = el.getAttribute('foreach');
-    const hidden = el.getAttribute('hidden');
-    const logic = el.getAttribute('logic');
+    let foreach = el.getAttribute('foreach')?.trim();
+    let hidden = el.getAttribute('hidden')?.trim();
+    const logic = el.getAttribute('logic')?.trim();
+
+    // まず値なしのパターンを処理
+    if (foreach === "") {
+        el.removeAttribute('foreach');
+        foreach = null;
+    }
+    if (hidden === "") {
+        el.removeAttribute('hidden');
+        hidden = null;
+    }
 
     // foreachとhidden両方ある場合はforeachのみlogic化、hiddenは警告のみ
     if (foreach && hidden && !logic) {

--- a/foreach_hidden_to_logic.test.js
+++ b/foreach_hidden_to_logic.test.js
@@ -29,6 +29,33 @@ describe("foreach/hidden属性→logic属性マイグレーション", () => {
         spy.mockRestore();
     });
 
+    it("foreach/hidden属性値に前後空白があっても正しく判定される", () => {
+        const spy = jest.spyOn(console, "warn").mockImplementation(() => { });
+        const inputXml = '<Grid foreach="  ${items}  " hidden="  ${isHidden}  "/>';
+        const yrtRoot = toYrtRoot({ layouts: [inputXml] });
+        const migrated = migrate(yrtRoot);
+        const { layouts } = fromYrtRoot(migrated);
+        const xml = layouts[0];
+        expect(xml).toContain('logic="foreach:${items}"');
+        expect(xml).not.toContain("foreach=");
+        expect(xml).toContain('hidden="  ${isHidden}  "'); // hiddenはlogic化されない
+        spy.mockRestore();
+    });
+
+    it("foreach/hidden属性値が空白のみの場合は変換・警告しない", () => {
+        const spy = jest.spyOn(console, "warn").mockImplementation(() => { });
+        const inputXml = '<Grid foreach="   " hidden="   "/>';
+        const yrtRoot = toYrtRoot({ layouts: [inputXml] });
+        const migrated = migrate(yrtRoot);
+        const { layouts } = fromYrtRoot(migrated);
+        const xml = layouts[0];
+        expect(xml).not.toContain("logic=");
+        expect(xml).not.toContain("foreach=");
+        expect(xml).not.toContain("hidden=");
+        expect(spy).not.toHaveBeenCalled();
+        spy.mockRestore();
+    });
+
     it("foreach属性とhidden属性が両方ある場合はforeachのみlogic化し、hiddenは警告のみで変換しない", () => {
         const spy = jest.spyOn(console, "warn").mockImplementation(() => { });
         const inputXml = '<?xml version="1.0" encoding="UTF-8"?>\n<Grid foreach="${items}" hidden="isHidden"/>';

--- a/grid_cols_rows_required_warn.mjs
+++ b/grid_cols_rows_required_warn.mjs
@@ -19,8 +19,8 @@ export function migrate(yrtRoot) {
         const grids = doc.getElementsByTagName("Grid");
         for (let i = 0; i < grids.length; i++) {
             const grid = grids[i];
-            const cols = grid.getAttribute("cols");
-            const rows = grid.getAttribute("rows");
+            const cols = grid.getAttribute("cols")?.trim();
+            const rows = grid.getAttribute("rows")?.trim();
             if (!cols || !rows) {
                 const xpath = getXPath(grid);
                 console.warn(`<Grid>のcols, rows属性は省略できません (両方必須): ${xpath}`);

--- a/grid_cols_rows_required_warn.test.js
+++ b/grid_cols_rows_required_warn.test.js
@@ -32,6 +32,20 @@ describe("<Grid> cols, rows属性省略不可警告マイグレーション", ()
         expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("<Grid>のcols, rows属性は省略できません"));
     });
 
+    it("cols, rows属性値に前後空白があっても正しく判定される", () => {
+        const xml = '<LinearLayout><Grid cols="   1 1 1   " rows="   1 1 1   "></Grid></LinearLayout>';
+        const yrtRoot = toYrtRoot({ layouts: [xml] });
+        migrate(yrtRoot);
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("cols, rows属性値が空白のみの場合は警告が出る", () => {
+        const xml = '<LinearLayout><Grid cols="   " rows="   "></Grid></LinearLayout>';
+        const yrtRoot = toYrtRoot({ layouts: [xml] });
+        migrate(yrtRoot);
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("<Grid>のcols, rows属性は省略できません"));
+    });
+
     it("cols, rows両方指定されていれば警告が出ない", () => {
         const xml = '<LinearLayout><Grid cols="1 1 1" rows="1 1 1"></Grid></LinearLayout>';
         const yrtRoot = toYrtRoot({ layouts: [xml] });

--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ import { migrate as sizeCommaToSpaceMigrate } from "./size_comma_to_space.mjs";
 import { migrate as borderstyleDasharrayToColonMigrate } from "./borderstyle_dasharray_to_colon.mjs";
 import { migrate as borderAdjacentLineWarning } from "./border_adjacent_line_warning.mjs";
 import { migrate as warnSpanColorBinding } from "./span_color_binding_warn.mjs";
+import { migrate as applySchema } from "./apply_schema.mjs";
 
 // dry-run時のXML整形出力を制御
 const DO_FORMAT_XML = true;
@@ -65,6 +66,9 @@ function migrate(newYrtRoot) {
     newYrtRoot = sizeCommaToSpaceMigrate(newYrtRoot);
     newYrtRoot = borderstyleDasharrayToColonMigrate(newYrtRoot);
     borderAdjacentLineWarning(newYrtRoot); // 警告のみ
+
+    // 最後にスキーマ指定用の属性追加
+    newYrtRoot = applySchema(newYrtRoot);
     return newYrtRoot;
 }
 

--- a/index.js
+++ b/index.js
@@ -17,12 +17,12 @@
  */
 
 import * as fs from "fs/promises";
-import * as multiple_xmls from "./multiple_xmls.mjs";
 import * as path from "path";
 import * as msgpack from "@msgpack/msgpack";
 import * as util from "util";
 import { yrtRootToPackage, packageToYrtRoot, isYrtRoot } from "./yrt_format.js";
 import { formatXml } from "./utils.js";
+import { migrate as layoutsToMultipleXmls } from "./multiple_xmls.mjs";
 import { migrate as removeContentElements } from "./remove_content_elements.mjs";
 import { migrate as styleElementMigrate } from "./style_element.mjs";
 import { migrate as foreachHiddenToLogicMigrate } from "./foreach_hidden_to_logic.mjs";
@@ -45,7 +45,7 @@ import { migrate as borderAdjacentLineWarning } from "./border_adjacent_line_war
 const DO_FORMAT_XML = true;
 
 function migrate(newYrtRoot) {
-    newYrtRoot = multiple_xmls.migrate(newYrtRoot);
+    newYrtRoot = layoutsToMultipleXmls(newYrtRoot);
     newYrtRoot = styleElementMigrate(newYrtRoot);
     newYrtRoot = removeContentElements(newYrtRoot);
     newYrtRoot = foreachHiddenToLogicMigrate(newYrtRoot);

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ import { migrate as rectangleBorderRadiusMultiWarnMigrate } from "./rectangle_bo
 import { migrate as sizeCommaToSpaceMigrate } from "./size_comma_to_space.mjs";
 import { migrate as borderstyleDasharrayToColonMigrate } from "./borderstyle_dasharray_to_colon.mjs";
 import { migrate as borderAdjacentLineWarning } from "./border_adjacent_line_warning.mjs";
+import { migrate as warnSpanColorBinding } from "./span_color_binding_warn.mjs";
 
 // dry-run時のXML整形出力を制御
 const DO_FORMAT_XML = true;
@@ -58,7 +59,7 @@ function migrate(newYrtRoot) {
     widthAutoRangeWarnMigrate(newYrtRoot); // 警告のみ
     newYrtRoot = colorNotationIllustratorMigrate(newYrtRoot);
     bindingRequiredWarnMigrate(newYrtRoot); // 警告のみ
-    spanColorBindingWarnMigrate(newYrtRoot); // 警告のみ
+    warnSpanColorBinding(newYrtRoot); // 警告のみ
     gridColsRowsRequiredWarnMigrate(newYrtRoot); // 警告のみ
     rectangleBorderRadiusMultiWarnMigrate(newYrtRoot); // 警告のみ
     newYrtRoot = sizeCommaToSpaceMigrate(newYrtRoot);

--- a/merge_directional_attrs.mjs
+++ b/merge_directional_attrs.mjs
@@ -91,7 +91,7 @@ function getUnifiedValue(element, base) {
 
 function mergeValues(attr, unified, individual) {
     let merged = [];
-    if (unified !== null && unified !== '') {
+    if (unified !== null && unified.trim() !== '') {
         const arr = unified.split(' ');
         for (let i = 0; i < attr.keys.length; i++) {
             merged[i] = arr[i] !== undefined ? arr[i] : arr[0];
@@ -102,7 +102,7 @@ function mergeValues(attr, unified, individual) {
         }
     }
     for (let i = 0; i < attr.keys.length; i++) {
-        if (individual[i] !== null && individual[i] !== '') merged[i] = individual[i];
+        if (individual[i] !== null && individual[i].trim() !== '') merged[i] = individual[i];
     }
     for (let i = 0; i < attr.keys.length; i++) {
         if (!merged[i]) merged[i] = attr.default;
@@ -121,7 +121,7 @@ function mergeDirectionalAttributes(element) {
     for (const attr of ATTR_MAP) {
         const individual = getIndividualValues(element, attr.keys);
         const unified = getUnifiedValue(element, attr.base);
-        const hasAnyIndividual = individual.some(v => v !== null && v !== '');
+        const hasAnyIndividual = individual.some(v => v !== null && v.trim() !== '');
         if (!hasAnyIndividual) continue;
         const merged = mergeValues(attr, unified, individual);
         if (isAllDefaultOrEmpty(merged, attr.default)) {
@@ -129,7 +129,7 @@ function mergeDirectionalAttributes(element) {
             continue;
         }
         removeDirectionalAttributes(element, attr);
-        element.setAttribute(attr.base, merged.join(' '));
+        element.setAttribute(attr.base, merged.map(s => s.trim()).join(' '));
     }
 }
 

--- a/merge_directional_attrs.mjs
+++ b/merge_directional_attrs.mjs
@@ -19,12 +19,12 @@ const ATTR_MAP = [
     {
         base: 'borderStyle',
         keys: ['borderTopStyle', 'borderRightStyle', 'borderBottomStyle', 'borderLeftStyle'],
-        default: 'none',
+        default: 'solid',
     },
     {
         base: 'borderColor',
         keys: ['borderTopColor', 'borderRightColor', 'borderBottomColor', 'borderLeftColor'],
-        default: 'transparent',
+        default: 'black',
     },
     {
         base: 'outerBorderThickness',
@@ -34,12 +34,12 @@ const ATTR_MAP = [
     {
         base: 'outerBorderStyle',
         keys: ['outerBorderTopStyle', 'outerBorderRightStyle', 'outerBorderBottomStyle', 'outerBorderLeftStyle'],
-        default: 'none',
+        default: 'solid',
     },
     {
         base: 'outerBorderColor',
         keys: ['outerBorderTopColor', 'outerBorderRightColor', 'outerBorderBottomColor', 'outerBorderLeftColor'],
-        default: 'transparent',
+        default: 'black',
     },
     {
         base: 'borderRadius',

--- a/merge_directional_attrs.test.js
+++ b/merge_directional_attrs.test.js
@@ -15,6 +15,18 @@ describe('mergeDirectionalAttributes', () => {
         assert.equal(output, expected);
     });
 
+    it('margin の統合（値に前後空白あり）', () => {
+        const input = '<StackLayout marginTop=" 1 " marginRight=" 2 " marginBottom=" 3 " marginLeft=" 4 "/>';
+        const expected = '<StackLayout margin="1 2 3 4"/>';
+        const yrtRoot = toYrtRoot({ layouts: [input] });
+        const migrated = migrate(yrtRoot);
+        const { layouts } = fromYrtRoot(migrated);
+        const doc = new DOMParser().parseFromString(layouts[0], 'text/xml');
+        const output = new XMLSerializer().serializeToString(doc.documentElement);
+        assert.equal(output, expected);
+        // 他の属性については、同一ロジックであるため同種のテストは省略します。
+    });
+
     it('borderColor の統合', () => {
         const input = '<LinearLayout borderTopColor="#111" borderRightColor="#222" borderBottomColor="#333" borderLeftColor="#444"/>';
         const expected = '<LinearLayout borderColor="#111 #222 #333 #444"/>';

--- a/merge_directional_attrs.test.js
+++ b/merge_directional_attrs.test.js
@@ -148,9 +148,9 @@ describe('mergeDirectionalAttributes', () => {
         assert.equal(output, expected);
     });
 
-    it('borderStyle の未指定部分はスキーマで許されている none で補完して4値で統合', () => {
-        const input = '<Grid borderTopStyle="solid" borderLeftStyle="dotted"/>';
-        const expected = '<Grid borderStyle="solid none none dotted"/>';
+    it('borderStyle の未指定部分はスキーマで許されている solid で補完して4値で統合', () => {
+        const input = '<Grid borderTopStyle="none" borderLeftStyle="dotted"/>';
+        const expected = '<Grid borderStyle="none solid solid dotted"/>';
         const yrtRoot = toYrtRoot({ layouts: [input] });
         const migrated = migrate(yrtRoot);
         const { layouts } = fromYrtRoot(migrated);
@@ -159,9 +159,9 @@ describe('mergeDirectionalAttributes', () => {
         assert.equal(output, expected);
     });
 
-    it('borderColor の未指定部分はスキーマで許されている transparent で補完して4値で統合', () => {
+    it('borderColor の未指定部分はスキーマで許されている black で補完して4値で統合', () => {
         const input = '<Grid borderTopColor="#111" borderLeftColor="#444"/>';
-        const expected = '<Grid borderColor="#111 transparent transparent #444"/>';
+        const expected = '<Grid borderColor="#111 black black #444"/>';
         const yrtRoot = toYrtRoot({ layouts: [input] });
         const migrated = migrate(yrtRoot);
         const { layouts } = fromYrtRoot(migrated);

--- a/multiple_xmls.mjs
+++ b/multiple_xmls.mjs
@@ -14,52 +14,39 @@
  * limitations under the License.
  */
 import xpath from 'xpath';
-import { XMLSerializer } from '@xmldom/xmldom';
+import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
 import { yrtRootToPackage, packageToYrtRoot } from './yrt_format.js';
 
 /**
  * `<LayoutXml>` 要素を削除し、1XML1レイアウト化するマイグレーション
  * 
  * 処理内容:
- * 1. `<LayoutXml>` 直下の `<LinearLayout>` または `<StackLayout>` をそれぞれ分割し、
+ * - `<LayoutXml>` 直下の `<LinearLayout>` または `<StackLayout>` をそれぞれ分割し、
  *    YRT の `layouts` 配列に順序通り格納する
- * 2. スタイル用の XML がなければ YRT の `style` に格納する（`<Style>` 要素をルートとするXML）
  * 
  * 注意事項:
  * - YRT ファイルはファイル名やIDで管理せず、`layouts`配列の順序でレイアウトを管理する
  * 
- * @param {Document} doc XMLドキュメント
- * @param {Object} yrtData YRTファイルのデータ（YRTファイルの場合のみ）
- * @returns {Object|null} 変更されたYRTデータ、またはXMLファイルの場合はnull
+ * @param {Object} yrtRoot v1.0 形式のYRT構造。
+ *   ただし alpha.13 からpack構造だけを変換した直後のものであり、
+ *   レイアウト配列の中には、alpha.13 の `<LayoutXml>` 要素を使ったXMLが一つだけ存在する想定
+ * @returns {Object} 変更されたYRTデータ
  */
-export function migrate(doc, yrtData = null) {
+export function migrate(yrtRoot) {
+    const layouts = yrtRoot[2].l;
+    if (layouts.length !== 1) {
+        throw new Error([
+            "At this point prior to migration, YRT root must contain exactly one XML",
+            "since yrtRoot has just been converted from the old format with only the object structure changed.",
+        ].join(" "));
+    }
+    const [_, xml] = layouts[0];
+    const doc = new DOMParser().parseFromString(xml, "text/xml");
+
     const layoutXmlElements = xpath.select("//LayoutXml", doc);
-    
-    if (!layoutXmlElements || layoutXmlElements.length === 0) {
-        return yrtData;
-    }
 
-    // YRTファイルの場合のみ、複数レイアウト分割処理を実行
-    if (yrtData) {
-        return migrateYrtFile(doc, yrtData, layoutXmlElements);
-    } else {
-        // XMLファイルの場合は単純に LayoutXml 要素を削除
-        return migrateXmlFile(doc, layoutXmlElements);
-    }
-}
-
-/**
- * YRTファイルの場合の1XML1レイアウト化処理
- * @param {Document} doc 
- * @param {Object} yrtData 
- * @param {Node[]} layoutXmlElements 
- * @returns {Object}
- */
-function migrateYrtFile(doc, yrtRoot, layoutXmlElements) {
-    // YrtRoot -> YrtPackage へ変換
     const pkg = yrtRootToPackage(yrtRoot);
     const newLayouts = [];
-    let styleXml = null;
 
     layoutXmlElements.forEach(layoutXmlElement => {
         // LayoutXml直下の LinearLayout または StackLayout を取得
@@ -73,53 +60,13 @@ function migrateYrtFile(doc, yrtRoot, layoutXmlElements) {
             const layoutXml = serializer.serializeToString(newDoc);
             newLayouts.push({ name: null, xml: layoutXml });
         });
-
-        // Style要素があるかチェック
-        const styleElements = xpath.select("Style", layoutXmlElement);
-        if (styleElements.length > 0 && !styleXml) {
-            const newDoc = doc.implementation.createDocument(null, null, null);
-            const clonedStyle = styleElements[0].cloneNode(true);
-            newDoc.appendChild(clonedStyle);
-            const serializer = new XMLSerializer();
-            styleXml = serializer.serializeToString(newDoc);
-        }
     });
 
     // layouts配列を上書き
     if (newLayouts.length > 0) {
         pkg.layouts = newLayouts;
     }
-    // styleがあれば上書き
-    if (styleXml) {
-        pkg.style = styleXml;
-    }
 
     // YrtPackage -> YrtRoot へ戻して返す
     return packageToYrtRoot(pkg);
-}
-
-/**
- * XMLファイルの場合のLayoutXml削除処理
- * @param {Document} doc 
- * @param {Node[]} layoutXmlElements 
- * @returns {null}
- */
-function migrateXmlFile(doc, layoutXmlElements) {
-    // LayoutXml直下のレイアウト要素をすべて抽出し、各レイアウトごとに新しいXML文字列として返す
-    const results = [];
-    layoutXmlElements.forEach(layoutXmlElement => {
-        // LayoutXml直下の要素（Elementノードのみ）
-        const layoutChildren = [];
-        for (let node = layoutXmlElement.firstChild; node; node = node.nextSibling) {
-            if (node.nodeType === 1) layoutChildren.push(node);
-        }
-        if (layoutChildren.length === 0) return;
-        layoutChildren.forEach(child => {
-            const newDoc = doc.implementation.createDocument(null, null, null);
-            newDoc.appendChild(child.cloneNode(true));
-            const serializer = new XMLSerializer();
-            results.push(serializer.serializeToString(newDoc));
-        });
-    });
-    return results;
 }

--- a/multiple_xmls.mjs
+++ b/multiple_xmls.mjs
@@ -65,6 +65,9 @@ export function migrate(yrtRoot) {
     // layouts配列を上書き
     if (newLayouts.length > 0) {
         pkg.layouts = newLayouts;
+    } else {
+        // LayoutBody 必須化については後続ステップで対応
+        pkg.layouts = [{ name: null, xml: "<LinearLayout></LinearLayout>" }];
     }
 
     // YrtPackage -> YrtRoot へ戻して返す

--- a/multiple_xmls.test.js
+++ b/multiple_xmls.test.js
@@ -13,40 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { DOMParser, XMLSerializer } from "@xmldom/xmldom";
 import * as multiple_xmls from "./multiple_xmls.mjs";
+import { yrtRootToPackage } from "./yrt_format.js";
 
 describe("multiple_xmls", () => {
-    describe("XMLファイルの場合", () => {
-        it("LayoutXml要素を削除して子要素を親に移動する", () => {
-            const inputXml = `<?xml version="1.0" encoding="UTF-8"?>
-<LayoutXml>
-    <LinearLayout direction="vertical">
-        <LayoutBody>
-            <Text>Hello</Text>
-        </LayoutBody>
-    </LinearLayout>
-    <StackLayout>
-        <Text>World</Text>
-    </StackLayout>
-</LayoutXml>`;
-
-            const doc = new DOMParser().parseFromString(inputXml, "text/xml");
-            const result = multiple_xmls.migrate(doc);
-
-            expect(Array.isArray(result)).toBe(true);
-            expect(result.length).toBe(2);
-            expect(result[0]).toContain("<LinearLayout");
-            expect(result[0]).toContain("<LayoutBody>");
-            expect(result[0]).toContain("<Text>Hello</Text>");
-            expect(result[1]).toContain("<StackLayout");
-            expect(result[1]).toContain("<Text>World</Text>");
-        });
-    });
-
-    describe("YRTファイルの場合", () => {
-        it("複数のレイアウトを分割してlayouts配列に格納する", () => {
-            const inputXml = `<?xml version="1.0" encoding="UTF-8"?>
+    it("LayoutXml直下の複数レイアウトを分割してlayouts配列に格納する", () => {
+        const inputXml = `<?xml version="1.0" encoding="UTF-8"?>
 <LayoutXml>
     <LinearLayout direction="vertical">
         <Text>Layout 1</Text>
@@ -54,48 +26,29 @@ describe("multiple_xmls", () => {
     <StackLayout>
         <Text>Layout 2</Text>
     </StackLayout>
-    <Style>
-        <Grid key="grid1">
-            <CellRange borderColor="black"/>
-        </Grid>
-    </Style>
 </LayoutXml>`;
+        // YRTルート形式: ["YRT", 1, { l: [[null, xml]], s: null, a: null }]
+        const yrtRoot = [
+            "YRT",
+            1,
+            {
+                l: [[null, inputXml]],
+                s: null,
+                a: null,
+            },
+        ];
+        const result = multiple_xmls.migrate(yrtRoot);
+        const pkg = yrtRootToPackage(result);
+        expect(pkg.layouts.length).toBe(2);
 
-            const doc = new DOMParser().parseFromString(inputXml, "text/xml");
-            const yrtData = [
-                "YRT",
-                1,
-                {
-                    l: [],
-                    s: null,
-                    a: null,
-                },
-            ];
+        expect(pkg.layouts[0].xml.startsWith("<LinearLayout")).toBe(true);
+        expect(pkg.layouts[0].xml).toContain("Layout 1");
+        expect(pkg.layouts[0].xml).not.toContain("Layout 2");
+        expect(pkg.layouts[0].xml.endsWith("</LinearLayout>")).toBe(true);
 
-            const result = multiple_xmls.migrate(doc, yrtData);
-
-            expect(Array.isArray(result)).toBe(true);
-            expect(result.length).toBeGreaterThanOrEqual(2);
-            const layouts = result[2].l;
-            expect(layouts[0][1]).toContain("<LinearLayout");
-            expect(layouts[0][1]).toContain("Layout 1");
-            expect(layouts[1][1]).toContain("<StackLayout");
-            expect(layouts[1][1]).toContain("Layout 2");
-            expect(result[2].s).toContain("<Style");
-        });
-
-        it("LayoutXml要素がない場合は元のデータをそのまま返す", () => {
-            const inputXml = `<?xml version="1.0" encoding="UTF-8"?>
-<LinearLayout>
-    <Text>Test</Text>
-</LinearLayout>`;
-
-            const doc = new DOMParser().parseFromString(inputXml, "text/xml");
-            const yrtData = [inputXml];
-
-            const result = multiple_xmls.migrate(doc, yrtData);
-
-            expect(result).toEqual(yrtData);
-        });
+        expect(pkg.layouts[1].xml.startsWith("<StackLayout")).toBe(true);
+        expect(pkg.layouts[1].xml).toContain("Layout 2");
+        expect(pkg.layouts[1].xml).not.toContain("Layout 1");
+        expect(pkg.layouts[1].xml.endsWith("</StackLayout>")).toBe(true);
     });
 });

--- a/multiple_xmls.test.js
+++ b/multiple_xmls.test.js
@@ -51,4 +51,28 @@ describe("multiple_xmls", () => {
         expect(pkg.layouts[1].xml).not.toContain("Layout 1");
         expect(pkg.layouts[1].xml.endsWith("</StackLayout>")).toBe(true);
     });
+
+    it("LinearLayout | StackLayout が見つからない場合、空の LinearLayout を追加する", () => {
+        const inputXml = `<?xml version="1.0" encoding="UTF-8"?>
+<LayoutXml>
+    <Text>Some other content</Text>
+    <Button>Not a layout element</Button>
+</LayoutXml>`;
+        // YRTルート形式: ["YRT", 1, { l: [[null, xml]], s: null, a: null }]
+        const yrtRoot = [
+            "YRT",
+            1,
+            {
+                l: [[null, inputXml]],
+                s: null,
+                a: null,
+            },
+        ];
+        const result = multiple_xmls.migrate(yrtRoot);
+        const pkg = yrtRootToPackage(result);
+        
+        expect(pkg.layouts.length).toBe(1);
+        expect(pkg.layouts[0].xml).toBe("<LinearLayout></LinearLayout>");
+        expect(pkg.layouts[0].name).toBe(null);
+    });
 });

--- a/rectangle_border_radius_multi_warn.mjs
+++ b/rectangle_border_radius_multi_warn.mjs
@@ -22,11 +22,8 @@ export function migrate(yrtRoot) {
             const borderRadius = rect.getAttribute("borderRadius");
             if (borderRadius === null) continue; // 未指定はOK
             const trimmed = borderRadius.trim();
-            // 空文字、またはスペース区切りで複数値の場合は警告
-            if (
-                trimmed === "" ||
-                trimmed.split(/\s+/).length > 1
-            ) {
+            // スペース区切りで複数値の場合は警告
+            if (trimmed.split(/\s+/).length > 1) {
                 const xpath = getXPath(rect);
                 console.warn(`<Rectangle>のborderRadius属性は単一値のみ許可されています（複数値は不正）: ${xpath}`);
             }

--- a/rectangle_border_radius_multi_warn.test.js
+++ b/rectangle_border_radius_multi_warn.test.js
@@ -33,11 +33,4 @@ describe("<Rectangle> borderRadius属性 複数方向指定警告マイグレー
         migrate(yrtRoot);
         expect(warnSpy).not.toHaveBeenCalled();
     });
-
-    it("noneなら警告が出ない", () => {
-        const xml = '<LinearLayout><Rectangle borderRadius="none"/></LinearLayout>';
-        const yrtRoot = toYrtRoot({ layouts: [xml] });
-        migrate(yrtRoot);
-        expect(warnSpy).not.toHaveBeenCalled();
-    });
 });

--- a/rectangle_border_radius_multi_warn.test.js
+++ b/rectangle_border_radius_multi_warn.test.js
@@ -27,13 +27,6 @@ describe("<Rectangle> borderRadius属性 複数方向指定警告マイグレー
         expect(warnSpy).toHaveBeenCalledTimes(2);
     });
 
-    it("空文字も警告を出す", () => {
-        const xml = '<LinearLayout><Rectangle borderRadius=""/></LinearLayout>';
-        const yrtRoot = toYrtRoot({ layouts: [xml] });
-        migrate(yrtRoot);
-        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("<Rectangle>のborderRadius属性は単一値のみ許可されています"));
-    });
-
     it("単一値なら警告が出ない", () => {
         const xml = '<LinearLayout><Rectangle borderRadius="5"/></LinearLayout>';
         const yrtRoot = toYrtRoot({ layouts: [xml] });

--- a/span_color_binding_warn.mjs
+++ b/span_color_binding_warn.mjs
@@ -6,7 +6,7 @@ function isBinding(val) {
 
 function checkSpan(node) {
     if (node.nodeType === 1 && node.nodeName === "Span") {
-        const color = node.getAttribute("color");
+        const color = node.getAttribute("color")?.trim();
         if (isBinding(color)) {
             const xpath = getXPath(node);
             console.warn(`<Span>のcolor属性にバインド変数は指定できません (値: ${color}) @ ${xpath}`);

--- a/span_color_binding_warn.mjs
+++ b/span_color_binding_warn.mjs
@@ -1,3 +1,4 @@
+import { DOMParser } from "@xmldom/xmldom";
 import { getXPath } from "./utils.js";
 
 function isBinding(val) {
@@ -20,6 +21,10 @@ function checkSpan(node) {
     }
 }
 
-export function migrate(doc) {
-    checkSpan(doc.documentElement);
+export function migrate(yrtRoot) {
+    yrtRoot[2].l.forEach(layout => {
+        const xml = layout[1];
+        const doc = new DOMParser().parseFromString(xml, "text/xml");
+        checkSpan(doc.documentElement);
+    });
 }

--- a/span_color_binding_warn.test.js
+++ b/span_color_binding_warn.test.js
@@ -1,6 +1,6 @@
 import { jest } from "@jest/globals";
-import { DOMParser } from "@xmldom/xmldom";
 import { migrate } from "./span_color_binding_warn.mjs";
+import { toYrtRoot } from "./utils.js";
 
 describe("<Span> color属性バインド変数警告マイグレーション", () => {
     let warnSpy;
@@ -13,44 +13,53 @@ describe("<Span> color属性バインド変数警告マイグレーション", (
 
     it("color属性がバインド変数の場合に警告が出る", () => {
         const xml = '<RichText><Span color="${foo}">text</Span></RichText>';
-        const doc = new DOMParser().parseFromString(xml, "text/xml");
-        migrate(doc);
+        const yrtRoot = toYrtRoot({ layouts: [xml] });
+        migrate(yrtRoot);
         expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("<Span>のcolor属性にバインド変数は指定できません"));
     });
 
     it("color属性値に前後空白があってもバインド変数なら警告が出る", () => {
         const xml = '<RichText><Span color="   ${foo}   ">text</Span></RichText>';
-        const doc = new DOMParser().parseFromString(xml, "text/xml");
-        migrate(doc);
+        const yrtRoot = toYrtRoot({ layouts: [xml] });
+        migrate(yrtRoot);
         expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("<Span>のcolor属性にバインド変数は指定できません"));
     });
 
     it("color属性が静的値の場合は警告が出ない", () => {
         const xml = `<RichText><Span color="#FF0000">text</Span></RichText>`;
-        const doc = new DOMParser().parseFromString(xml, "text/xml");
-        migrate(doc);
+        const yrtRoot = toYrtRoot({ layouts: [xml] });
+        migrate(yrtRoot);
         expect(warnSpy).not.toHaveBeenCalled();
     });
 
     it("color属性が未指定の場合は警告が出ない", () => {
         const xml = `<RichText><Span>text</Span></RichText>`;
-        const doc = new DOMParser().parseFromString(xml, "text/xml");
-        migrate(doc);
+        const yrtRoot = toYrtRoot({ layouts: [xml] });
+        migrate(yrtRoot);
         expect(warnSpy).not.toHaveBeenCalled();
     });
 
     it("複数の<Span>でバインド変数指定があれば全て警告", () => {
         const xml = '<RichText><Span color="${foo}"/><Span color="${bar}"/></RichText>';
-        const doc = new DOMParser().parseFromString(xml, "text/xml");
-        migrate(doc);
+        const yrtRoot = toYrtRoot({ layouts: [xml] });
+        migrate(yrtRoot);
         expect(warnSpy).toHaveBeenCalledTimes(2);
     });
 
     it("入れ子の<Span>でバインド変数指定があれば全て警告", () => {
         const xml = '<RichText><Span color="#000000">outer<Span color="${foo}">inner</Span></Span></RichText>';
-        const doc = new DOMParser().parseFromString(xml, "text/xml");
-        migrate(doc);
+        const yrtRoot = toYrtRoot({ layouts: [xml] });
+        migrate(yrtRoot);
         expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("<Span>のcolor属性にバインド変数は指定できません"));
+    });
+
+    it("複数XMLでそれぞれのcolor属性バインド変数に警告が出る", () => {
+        const xml1 = '<RichText><Span color="${foo}">text1</Span></RichText>';
+        const xml2 = '<RichText><Span color="${bar}">text2</Span></RichText>';
+        const yrtRoot = toYrtRoot({ layouts: [xml1, xml2] });
+        migrate(yrtRoot);
+        expect(warnSpy).toHaveBeenCalledTimes(2);
         expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("<Span>のcolor属性にバインド変数は指定できません"));
     });
 });

--- a/span_color_binding_warn.test.js
+++ b/span_color_binding_warn.test.js
@@ -18,6 +18,13 @@ describe("<Span> color属性バインド変数警告マイグレーション", (
         expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("<Span>のcolor属性にバインド変数は指定できません"));
     });
 
+    it("color属性値に前後空白があってもバインド変数なら警告が出る", () => {
+        const xml = '<RichText><Span color="   ${foo}   ">text</Span></RichText>';
+        const doc = new DOMParser().parseFromString(xml, "text/xml");
+        migrate(doc);
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("<Span>のcolor属性にバインド変数は指定できません"));
+    });
+
     it("color属性が静的値の場合は警告が出ない", () => {
         const xml = `<RichText><Span color="#FF0000">text</Span></RichText>`;
         const doc = new DOMParser().parseFromString(xml, "text/xml");

--- a/style_element.mjs
+++ b/style_element.mjs
@@ -40,8 +40,8 @@ export function migrate(yrtRoot) {
         for (const { tag, styleTag } of STYLE_TARGETS) {
             const targets = Array.from(doc.getElementsByTagName(tag));
             for (const target of targets) {
-                const styleElem = target.getElementsByTagName(styleTag)[0];
-                if (styleElem) {
+                const styleElems = Array.from(target.getElementsByTagName(styleTag));
+                for (const styleElem of styleElems) {
                     const styleId = `styleelement-${styleIndex++}`;
                     target.setAttribute("style", styleId);
                     // Style XMLに追加

--- a/style_element.mjs
+++ b/style_element.mjs
@@ -52,6 +52,12 @@ export function migrate(yrtRoot) {
                         const attr = styleElem.attributes[j];
                         cellRange.setAttribute(attr.name, attr.value);
                     }
+                    if (!cellRange.hasAttribute("col")) {
+                        cellRange.setAttribute("col", "all");
+                    }
+                    if (!cellRange.hasAttribute("row")) {
+                        cellRange.setAttribute("row", "all");
+                    }
                     styleTargetElem.appendChild(cellRange);
                     styleRoot.appendChild(styleTargetElem);
                     target.removeChild(styleElem);

--- a/style_element.test.js
+++ b/style_element.test.js
@@ -91,6 +91,34 @@ describe("style_element", () => {
         expect((styleXml.match(/<Style>/g) || []).length).toBe(1);
     });
 
+    it("同一親要素内に複数のXxxStyle要素が存在した場合に、すべてが正しく移行される", () => {
+        const inputXml = `<?xml version="1.0" encoding="UTF-8"?>
+<LayoutXml>
+  <Grid>
+    <GridStyle borderColor="red" col="1" row="1"/>
+    <GridStyle borderColor="blue" col="2" row="2"/>
+    <GridStyle borderColor="green" col="3" row="3"/>
+    <Text>test</Text>
+  </Grid>
+</LayoutXml>`;
+        const yrt = migrate(toYrtRoot({ layouts: [inputXml] }));
+        const { layouts, styleXml } = fromYrtRoot(yrt);
+
+        // レイアウトXMLから全てのGridStyleが削除されていることを確認
+        expect(layouts[0]).not.toContain("<GridStyle");
+
+        // Style XMLに3つのGrid要素が追加されていることを確認
+        expect((styleXml.match(/<Grid/g) || []).length).toBe(3);
+        expect(styleXml).toContain('<Grid key="styleelement-1"');
+        expect(styleXml).toContain('<Grid key="styleelement-2"');
+        expect(styleXml).toContain('<Grid key="styleelement-3"');
+
+        // 各CellRangeが正しく設定されていることを確認
+        expect(styleXml).toContain('<CellRange borderColor="red" col="1" row="1"');
+        expect(styleXml).toContain('<CellRange borderColor="blue" col="2" row="2"');
+        expect(styleXml).toContain('<CellRange borderColor="green" col="3" row="3"');
+    });
+
     describe("CellRange col/raw 必須化", () => {
         it("GridStyleにcol/row属性がない場合、CellRangeに col=\"all\" row=\"all\" が自動追加される", () => {
             const inputXml = `<?xml version="1.0" encoding="UTF-8"?>\n<LayoutXml>\n  <Grid>\n    <GridStyle borderColor=\"red\" foreach=\"item\"/>\n    <Text>test</Text>\n  </Grid>\n</LayoutXml>`;

--- a/style_element.test.js
+++ b/style_element.test.js
@@ -1,4 +1,3 @@
-import { DOMParser, XMLSerializer } from "@xmldom/xmldom";
 import { migrate } from "./style_element.mjs";
 import { toYrtRoot, fromYrtRoot } from "./utils.js";
 
@@ -90,5 +89,37 @@ describe("style_element", () => {
         expect(styleXml).toContain('<Table key="styleelement-2"');
         expect(styleXml).toContain('<CellRange borderColor="blue"');
         expect((styleXml.match(/<Style>/g) || []).length).toBe(1);
+    });
+
+    describe("CellRange col/raw 必須化", () => {
+        it("GridStyleにcol/row属性がない場合、CellRangeに col=\"all\" row=\"all\" が自動追加される", () => {
+            const inputXml = `<?xml version="1.0" encoding="UTF-8"?>\n<LayoutXml>\n  <Grid>\n    <GridStyle borderColor=\"red\" foreach=\"item\"/>\n    <Text>test</Text>\n  </Grid>\n</LayoutXml>`;
+            const yrt = migrate(toYrtRoot({ layouts: [inputXml] }));
+            const { styleXml } = fromYrtRoot(yrt);
+            expect(styleXml).toContain('<CellRange borderColor="red" foreach="item" col="all" row="all"');
+        });
+
+        it("TableStyleにcol属性のみがない場合、CellRangeに col=\"all\" が自動追加される", () => {
+            const inputXml = `<?xml version="1.0" encoding="UTF-8"?>\n<LayoutXml>\n  <Table>\n    <TableStyle borderColor=\"blue\" row=\"1\"/>\n    <TableColumn>\n      <TableColumnTemplate>\n        <Text>row</Text>\n      </TableColumnTemplate>\n    </TableColumn>\n  </Table>\n</LayoutXml>`;
+            const yrt = migrate(toYrtRoot({ layouts: [inputXml] }));
+            const { styleXml } = fromYrtRoot(yrt);
+            expect(styleXml).toContain('<CellRange borderColor="blue" row="1" col="all"');
+        });
+
+        it("ColumnTextStyleにrow属性のみがない場合、CellRangeに row=\"all\" が自動追加される", () => {
+            const inputXml = `<?xml version="1.0" encoding="UTF-8"?>\n<LayoutXml>\n  <ColumnText>\n    <ColumnTextStyle borderColor=\"green\" col=\"2\"/>\n    <ColumnTextContent>abc</ColumnTextContent>\n  </ColumnText>\n</LayoutXml>`;
+            const yrt = migrate(toYrtRoot({ layouts: [inputXml] }));
+            const { styleXml } = fromYrtRoot(yrt);
+            expect(styleXml).toContain('<CellRange borderColor="green" col="2" row="all"');
+        });
+
+        it("既にcol/row属性が存在する場合は上書きされない", () => {
+            const inputXml = `<?xml version="1.0" encoding="UTF-8"?>\n<LayoutXml>\n  <Grid>\n    <GridStyle borderColor=\"red\" col=\"1\" row=\"2\"/>\n    <Text>test</Text>\n  </Grid>\n</LayoutXml>`;
+            const yrt = migrate(toYrtRoot({ layouts: [inputXml] }));
+            const { styleXml } = fromYrtRoot(yrt);
+            expect(styleXml).toContain('<CellRange borderColor="red" col="1" row="2"');
+            expect(styleXml).not.toContain('col="all"');
+            expect(styleXml).not.toContain('row="all"');
+        });
     });
 });

--- a/width_auto_range_warn.mjs
+++ b/width_auto_range_warn.mjs
@@ -17,9 +17,11 @@ export function migrate(yrtRoot) {
         function checkGridCols(node) {
             if (node.nodeType === 1 && node.tagName === 'Grid' && node.hasAttribute('cols')) {
                 const val = node.getAttribute('cols')?.trim();
-                if ((typeof val === 'string' && val.trim().toLowerCase() === 'auto') || /^\d*:\d*$/.test(val)) {
-                    const xpath = getXPath(node);
-                    warnings.push(`<Grid> の cols 属性に警告: cols=\"${val}\"（XPath: ${xpath}）`);
+                if (typeof val === 'string') {
+                    if ((val.trim().toLowerCase() === 'auto') || val.includes(":")) {
+                        const xpath = getXPath(node);
+                        warnings.push(`<Grid> の cols 属性に警告: cols=\"${val}\"（XPath: ${xpath}）`);
+                    }
                 }
             }
             if (node.childNodes) {
@@ -31,9 +33,11 @@ export function migrate(yrtRoot) {
         function checkTableColumnWidth(node) {
             if (node.nodeType === 1 && node.tagName === 'TableColumn' && node.hasAttribute('width')) {
                 const val = node.getAttribute('width')?.trim();
-                if ((typeof val === 'string' && val.trim().toLowerCase() === 'auto') || /^\d*:\d*$/.test(val)) {
-                    const xpath = getXPath(node);
-                    warnings.push(`<TableColumn> の width 属性に警告: width=\"${val}\"（XPath: ${xpath}）`);
+                if (typeof val === 'string') {
+                    if (val.trim().toLowerCase() === 'auto' || val.includes(":")) {
+                        const xpath = getXPath(node);
+                        warnings.push(`<TableColumn> の width 属性に警告: width=\"${val}\"（XPath: ${xpath}）`);
+                    }
                 }
             }
             if (node.childNodes) {

--- a/width_auto_range_warn.mjs
+++ b/width_auto_range_warn.mjs
@@ -17,7 +17,7 @@ export function migrate(yrtRoot) {
         function checkGridCols(node) {
             if (node.nodeType === 1 && node.tagName === 'Grid' && node.hasAttribute('cols')) {
                 const val = node.getAttribute('cols')?.trim();
-                if (val === 'auto' || /^\d*:\d*$/.test(val)) {
+                if ((typeof val === 'string' && val.trim().toLowerCase() === 'auto') || /^\d*:\d*$/.test(val)) {
                     const xpath = getXPath(node);
                     warnings.push(`<Grid> の cols 属性に警告: cols=\"${val}\"（XPath: ${xpath}）`);
                 }
@@ -31,7 +31,7 @@ export function migrate(yrtRoot) {
         function checkTableColumnWidth(node) {
             if (node.nodeType === 1 && node.tagName === 'TableColumn' && node.hasAttribute('width')) {
                 const val = node.getAttribute('width')?.trim();
-                if (val === 'auto' || /^\d*:\d*$/.test(val)) {
+                if ((typeof val === 'string' && val.trim().toLowerCase() === 'auto') || /^\d*:\d*$/.test(val)) {
                     const xpath = getXPath(node);
                     warnings.push(`<TableColumn> の width 属性に警告: width=\"${val}\"（XPath: ${xpath}）`);
                 }

--- a/width_auto_range_warn.mjs
+++ b/width_auto_range_warn.mjs
@@ -16,7 +16,7 @@ export function migrate(yrtRoot) {
         const doc = new DOMParser().parseFromString(xml, "text/xml");
         function checkGridCols(node) {
             if (node.nodeType === 1 && node.tagName === 'Grid' && node.hasAttribute('cols')) {
-                const val = node.getAttribute('cols');
+                const val = node.getAttribute('cols')?.trim();
                 if (val === 'auto' || /^\d*:\d*$/.test(val)) {
                     const xpath = getXPath(node);
                     warnings.push(`<Grid> の cols 属性に警告: cols=\"${val}\"（XPath: ${xpath}）`);
@@ -30,7 +30,7 @@ export function migrate(yrtRoot) {
         }
         function checkTableColumnWidth(node) {
             if (node.nodeType === 1 && node.tagName === 'TableColumn' && node.hasAttribute('width')) {
-                const val = node.getAttribute('width');
+                const val = node.getAttribute('width')?.trim();
                 if (val === 'auto' || /^\d*:\d*$/.test(val)) {
                     const xpath = getXPath(node);
                     warnings.push(`<TableColumn> の width 属性に警告: width=\"${val}\"（XPath: ${xpath}）`);

--- a/width_auto_range_warn.test.js
+++ b/width_auto_range_warn.test.js
@@ -42,6 +42,15 @@ describe("<Grid> cols属性のauto/range廃止マイグレーション 警告出
         spy.mockRestore();
     });
 
+    it("cols='3.5:4.5' で警告が出る", () => {
+        const spy = jest.spyOn(console, "warn").mockImplementation(() => { });
+        const xml = `<Grid cols="3.5:4.5"></Grid>`;
+        const yrtRoot = toYrtRoot({ layouts: [xml] });
+        migrate(yrtRoot);
+        expect(spy.mock.calls.flat().join("\n")).toMatch(/cols.*3.5:4.5/);
+        spy.mockRestore();
+    });
+
     it("cols=':20', cols='10:' でも警告が出る", () => {
         const spy = jest.spyOn(console, "warn").mockImplementation(() => { });
         const xml1 = `<Grid cols=":20"></Grid>`;
@@ -99,6 +108,14 @@ describe("<TableColumn> width属性のauto/range廃止マイグレーション �
         const yrtRoot = toYrtRoot({ layouts: [xml] });
         migrate(yrtRoot);
         expect(spy.mock.calls.flat().join("\n")).toMatch(/width.*5:10/);
+        spy.mockRestore();
+    });
+    it("width='5.5:10.5' で警告が出る", () => {
+        const spy = jest.spyOn(console, "warn").mockImplementation(() => { });
+        const xml = `<TableColumn width="5.5:10.5"></TableColumn>`;
+        const yrtRoot = toYrtRoot({ layouts: [xml] });
+        migrate(yrtRoot);
+        expect(spy.mock.calls.flat().join("\n")).toMatch(/width.*5.5:10.5/);
         spy.mockRestore();
     });
 

--- a/width_auto_range_warn.test.js
+++ b/width_auto_range_warn.test.js
@@ -16,6 +16,15 @@ describe("<Grid> cols属性のauto/range廃止マイグレーション 警告出
         spy.mockRestore();
     });
 
+    it("cols='  auto  '（前後空白あり）で警告が出る", () => {
+        const spy = jest.spyOn(console, "warn").mockImplementation(() => { });
+        const xml = `<Grid cols="  auto  "></Grid>`;
+        const yrtRoot = toYrtRoot({ layouts: [xml] });
+        migrate(yrtRoot);
+        expect(spy.mock.calls.flat().join("\n")).toMatch(/cols.*auto/);
+        spy.mockRestore();
+    });
+
     it("cols='10:20' で警告が出る", () => {
         const spy = jest.spyOn(console, "warn").mockImplementation(() => { });
         const xml = `<Grid cols="10:20"></Grid>`;
@@ -53,6 +62,15 @@ describe("<TableColumn> width属性のauto/range廃止マイグレーション �
     it("width='auto' で警告が出る", () => {
         const spy = jest.spyOn(console, "warn").mockImplementation(() => { });
         const xml = `<TableColumn width="auto"></TableColumn>`;
+        const yrtRoot = toYrtRoot({ layouts: [xml] });
+        migrate(yrtRoot);
+        expect(spy.mock.calls.flat().join("\n")).toMatch(/TableColumn.*width.*auto/);
+        spy.mockRestore();
+    });
+
+    it("width='  auto  '（前後空白あり）で警告が出る", () => {
+        const spy = jest.spyOn(console, "warn").mockImplementation(() => { });
+        const xml = `<TableColumn width="  auto  "></TableColumn>`;
         const yrtRoot = toYrtRoot({ layouts: [xml] });
         migrate(yrtRoot);
         expect(spy.mock.calls.flat().join("\n")).toMatch(/TableColumn.*width.*auto/);

--- a/width_auto_range_warn.test.js
+++ b/width_auto_range_warn.test.js
@@ -24,6 +24,14 @@ describe("<Grid> cols属性のauto/range廃止マイグレーション 警告出
         expect(spy.mock.calls.flat().join("\n")).toMatch(/cols.*auto/);
         spy.mockRestore();
     });
+    it("cols='AuTo'（大文字・小文字混在）で警告が出る", () => {
+        const spy = jest.spyOn(console, "warn").mockImplementation(() => { });
+        const xml = `<Grid cols="AuTo"></Grid>`;
+        const yrtRoot = toYrtRoot({ layouts: [xml] });
+        migrate(yrtRoot);
+        expect(spy.mock.calls.flat().join("\n")).toMatch(/cols.*AuTo/);
+        spy.mockRestore();
+    });
 
     it("cols='10:20' で警告が出る", () => {
         const spy = jest.spyOn(console, "warn").mockImplementation(() => { });
@@ -74,6 +82,14 @@ describe("<TableColumn> width属性のauto/range廃止マイグレーション �
         const yrtRoot = toYrtRoot({ layouts: [xml] });
         migrate(yrtRoot);
         expect(spy.mock.calls.flat().join("\n")).toMatch(/TableColumn.*width.*auto/);
+        spy.mockRestore();
+    });
+    it("width='AuTo'（大文字・小文字混在）で警告が出る", () => {
+        const spy = jest.spyOn(console, "warn").mockImplementation(() => { });
+        const xml = `<TableColumn width="AuTo"></TableColumn>`;
+        const yrtRoot = toYrtRoot({ layouts: [xml] });
+        migrate(yrtRoot);
+        expect(spy.mock.calls.flat().join("\n")).toMatch(/width.*AuTo/);
         spy.mockRestore();
     });
 


### PR DESCRIPTION
## 動作に最低限必要な修正

- 1ファイル1レイアウト化 (multiple_xmls)：
    - migrate() の引数およびロジックを修正
        - （備考）たぶん最初期に作ったために、作成時点では旧形式と新形式の区別が曖昧だったのかなと推測します
- span_color_binding_warn.mjs
    - migrate() のimport漏れおよび引数を修正
        - （備考）引数が doc だったので他と同様 yrtRoot に統一

## 処理内容の修正（全属性共通）

- 属性値の冒頭末尾やトークン間に空白があるケースにも対応
    - （備考）対象ファイル多め。コロン前後は例外的に空白禁止だが、基本的には空白寛容の原則
- 属性値の検知を case-insensitive に修正
    - （備考）`width="Auto"`, `color="Rgb(...)"`, `borderStyle="DashArray(...)"` など

## 処理内容の修正（個別）

- 1ファイル1レイアウト化 (multiple_xmls)：
    - エッジケースとして `<LayoutXml>` が空のケースに対応
        - （備考）`<LinearLayout>` のほうに決め打ちすることで対応
- color系属性の記法変更
    - 処理対象属性の漏れを修正
        - （備考）Table の `(header|footer)BackgroundColor`
- Rectangle borderRadius 4方向指定廃止
    - 空文字（空白文字のみのケース含む）に対する警告を削除
        - （備考）必須属性ではなく、CHANGELOG の「単一の値のみを指定可能」は「値なし」を禁止する意図なし
- 罫線統合 (merge_directional_attrs.mjs)
    - borderColor/Style 系のデフォルト値を修正
        - （備考）罫線系のデフォルト値は基本的に `0 black solid` or `regular black solid` （太さは要素と属性による）
- width の auto/range の警告
    - range について float も検知するよう修正
        - （備考）`1.5:2.5` など
- Style系要素 -> StyleXML CellRange
    - CellRange col/row を必ず指定するよう修正
        - （備考）移植元の GridStyle 等では省略可能だった
    - 旧Style系要素が複数あると1つしか移行されないのを修正

## 機能追加

- XMLスキーマ用の属性を追加する機能 (apply_schema.mjs)