### PR TITLE
LayoutXMLの整形が過剰なためにレイアウトが壊れるのを修正

### DIFF
--- a/formatter.mjs
+++ b/formatter.mjs
@@ -1,0 +1,120 @@
+/**
+ * 与えられたXML文字列について、2行目以降の共通インデントを除去することで整形します。
+ *
+ * ### 背景
+ * 本プロジェクトには、DOM操作によってXMLのルートノードを削除する処理があります。
+ * しかしその結果を serialize すると、1行目だけが行の先頭に来て、2行目以降は元のXMLのインデントが残ります。
+ * これを整形する必要がありますが、一部のテキスト系要素（`<Text>` など）は whitespace-sensitive であるため、
+ * 不要なインデントだけを慎重に除去する必要があります。
+ *
+ * ### 仕様
+ * - すべてのタブ文字を2スペースに変換します。
+ *   タブが検出された場合は警告を出力します。
+ * - 各行の先頭スペース数の最小値を検出し、その分だけ各行の先頭スペースを除去します。
+ *   これにより、元の相対インデントは維持されます。
+ *   ただし、下記の条件にあてはまる行は、最小値の検出においても先頭スペース除去においても無視します:
+ *   - 全体の最初の行
+ *   - 空行または空白文字のみである
+ *   - 行の最初の非空白文字が、開始ブラケット `<` ではない
+ *   - 行の最初の非空白文字列が、テキスト系要素 (Text, Link, VText, RichText, Span) の終了タグで始まる
+ *
+ * @param {string} xml XML文字列
+ * @returns {string} インデント除去・タブ正規化済みXML文字列
+ */
+export function removeIndents(xml) {
+    // タブを2スペースに変換
+    if (xml.includes('\t')) {
+        console.warn(`[WARNING] TAB文字が検出されました。半角スペースx2 に変換します。`);
+        xml = xml.replace(/\t/g, '  ');
+    }
+    const lines = xml.split('\n');
+
+    // エッジケース: 空文字列、1行のみの場合はそのまま返す
+    if (lines.length <= 1) {
+        return xml;
+    }
+
+    // 空白文字のみの行をトリム
+    const processedLines = lines.map((line) => {
+        if (line.trim() === '') return '';
+        return line;
+    });
+
+    // 最小インデント数を検出（1行目と除外条件の行以外から）
+    let minIndent = Infinity;
+    for (let i = 1; i < processedLines.length; i++) {
+        const line = processedLines[i];
+        if (shouldIgnoreForIndentDetection(line)) continue;
+        const indentCount = getLeadingSpaceCount(line);
+        minIndent = Math.min(minIndent, indentCount);
+    }
+
+    // 有効な最小インデントが見つからない場合はそのまま返す
+    if (minIndent === Infinity) {
+        return processedLines.join('\n');
+    }
+
+    // 各行から最小インデント分を除去
+    const result = processedLines.map((line, index) => {
+        if (index === 0 || shouldIgnoreForIndentDetection(line)) {
+            return line;
+        }
+        if (line.length >= minIndent) {
+            return line.slice(minIndent);
+        }
+        return line;
+    });
+
+    return result.join('\n');
+}
+
+/**
+ * テキスト系要素（テキストノードを内容に持ちうる要素）のリスト。
+ * ※ ColumnText はそもそも改行を含むことがありえないため除外
+ * 
+ * @see isTextElementEndTag
+ */
+const textLikeElementNames = ['Text', 'Link', 'VText', 'RichText', 'Span'];
+
+/**
+ * テキスト系要素の終了タグで始まるかどうかを判定
+ * @param {string} trimmedLine トリム済みの行
+ * @returns {boolean}
+ */
+function isTextElementEndTag(trimmedLine) {
+    return textLikeElementNames.some(element => trimmedLine.startsWith(`</${element}>`));
+}
+
+/**
+ * インデント検出において無視すべき行かどうかを判定
+ * @param {string} line 行文字列
+ * @returns {boolean}
+ */
+function shouldIgnoreForIndentDetection(line) {
+    const trimmed = line.trim();
+
+    // 空行または空白文字のみの行なら無視
+    if (trimmed === '') return true;
+
+    // 行の最初の非空白文字が開始ブラケットではないなら無視
+    if (!trimmed.startsWith('<')) return true;
+
+    // 行の最初の非空白文字列がテキスト系要素の終了タグで始まるなら無視
+    if (isTextElementEndTag(trimmed)) return true;
+
+    return false;
+}
+
+/**
+ * 行の先頭スペース数を取得
+ * @param {string} line 行文字列
+ * @returns {number}
+ */
+function getLeadingSpaceCount(line) {
+    let count = 0;
+    for (let i = 0; i < line.length; i++) {
+        if (line[i] === ' ') count++;
+        else break;
+    }
+    return count;
+}

--- a/formatter.mjs
+++ b/formatter.mjs
@@ -46,7 +46,7 @@ export function removeIndents(xml) {
         console.warn(`[WARNING] TAB文字が検出されました。半角スペースx2 に変換します。`);
         xml = xml.replace(/\t/g, '  ');
     }
-    const lines = xml.split('\n');
+    const lines = xml.split(/\r\n|\r|\n/);
 
     // エッジケース: 空文字列、1行のみの場合はそのまま返す
     if (lines.length <= 1) {

--- a/formatter.mjs
+++ b/formatter.mjs
@@ -1,3 +1,22 @@
+import xmlFormat from "xml-formatter";
+
+/**
+ * xml-formatter を使って2スペースインデントで整形します。
+ *
+ * 主に StyleXML に対して使用します。
+ * LayoutXML にはこの関数ではなく `removeIndents()` のほうを使用してください。
+ * 
+ * @param {string} xml XML文字列
+ * @returns {string} 整形済みXML
+ */
+export function formatXmlPretty(xml) {
+    return xmlFormat(xml, {
+        indentation: "  ",
+        lineSeparator: "\n",
+        whiteSpaceAtEndOfSelfclosingTag: true,
+    });
+}
+
 /**
  * 与えられたXML文字列について、2行目以降の共通インデントを除去することで整形します。
  *

--- a/formatter.test.js
+++ b/formatter.test.js
@@ -1,0 +1,533 @@
+import { jest } from "@jest/globals";
+import { removeIndents } from "./formatter.mjs";
+
+describe("removeIndents", () => {
+    it("典型ケース: 2行目以降の全行が余分なインデントを持つ", () => {
+        const input = [
+            '<LinearLayout>',
+            '    <LayoutBody>',
+            '      <Text>text</Text>',
+            '    </LayoutBody>',
+            '  </LinearLayout>'
+        ].join('\n');
+        const expected = [
+            '<LinearLayout>',
+            '  <LayoutBody>',
+            '    <Text>text</Text>',
+            '  </LayoutBody>',
+            '</LinearLayout>'
+        ].join('\n');
+        expect(removeIndents(input)).toBe(expected);
+    });
+
+    it("1行目以外にインデント0の行（除外対象ではないもの）があれば、全てのインデントは削除されない", () => {
+        const input = [
+            '<LinearLayout>',
+            '    <LayoutBody>',
+            '<Text>text</Text>', // the minimum indentation is 0 due to this line
+            '    </LayoutBody>',
+            '  </LinearLayout>'
+        ].join('\n');
+        const expected = [
+            '<LinearLayout>',
+            '    <LayoutBody>',
+            '<Text>text</Text>',
+            '    </LayoutBody>',
+            '  </LinearLayout>'
+        ].join('\n');
+        expect(removeIndents(input)).toBe(expected);
+    });
+
+    it("空行は無視される", () => {
+        const input = [
+            '<LinearLayout>',
+            '',
+            '    <LayoutBody>',
+            '      <Text>text</Text>',
+            '    </LayoutBody>',
+            '',
+            '  </LinearLayout>'
+        ].join('\n');
+        const expected = [
+            '<LinearLayout>',
+            '',
+            '  <LayoutBody>',
+            '    <Text>text</Text>',
+            '  </LayoutBody>',
+            '',
+            '</LinearLayout>'
+        ].join('\n');
+        expect(removeIndents(input)).toBe(expected);
+    });
+
+    it("空白文字のみの行はトリムされる", () => {
+        const input = [
+            '<LinearLayout>',
+            '        ',
+            '    <LayoutBody>',
+            '      <Text>text</Text>',
+            '    </LayoutBody>',
+            '        ',
+            '  </LinearLayout>'
+        ].join('\n');
+        const expected = [
+            '<LinearLayout>',
+            '',
+            '  <LayoutBody>',
+            '    <Text>text</Text>',
+            '  </LayoutBody>',
+            '',
+            '</LinearLayout>'
+        ].join('\n');
+        expect(removeIndents(input)).toBe(expected);
+    });
+
+    it("タブが含まれる場合は 2 spaces に変換され、警告が出力される", () => {
+        const input = [
+            '<LinearLayout>',
+            '\t\t<LayoutBody>',
+            '\t\t\t<Text>text</Text>',
+            '\t\t</LayoutBody>',
+            '\t</LinearLayout>'
+        ].join('\n');
+        const expected = [
+            '<LinearLayout>',
+            '  <LayoutBody>',
+            '    <Text>text</Text>',
+            '  </LayoutBody>',
+            '</LinearLayout>'
+        ].join('\n');
+        // 警告が出ることも確認
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => { });
+        expect(removeIndents(input)).toBe(expected);
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('TAB文字が検出されました'));
+        warnSpy.mockRestore();
+    });
+
+    it("インデントがバラバラでも最小値だけ除去される", () => {
+        const input = [
+            '<LinearLayout>',
+            '    <LayoutBody>',
+            '      <Text>text</Text>',
+            '        <Text>more</Text>',
+            '    </LayoutBody>',
+            '  </LinearLayout>'
+        ].join('\n');
+        const expected = [
+            '<LinearLayout>',
+            '  <LayoutBody>',
+            '    <Text>text</Text>',
+            '      <Text>more</Text>',
+            '  </LayoutBody>',
+            '</LinearLayout>'
+        ].join('\n');
+        expect(removeIndents(input)).toBe(expected);
+    });
+
+    it("要素内で同行内の空白は保持される", () => {
+        const input = [
+            '<LinearLayout>',
+            '    <LayoutBody>',
+            '      <Text>   text</Text>',
+            '    </LayoutBody>',
+            '  </LinearLayout>'
+        ].join('\n');
+        const expected = [
+            '<LinearLayout>',
+            '  <LayoutBody>',
+            '    <Text>   text</Text>',
+            '  </LayoutBody>',
+            '</LinearLayout>'
+        ].join('\n');
+        expect(removeIndents(input)).toBe(expected);
+    });
+
+    describe("行の最初の非空白文字がXMLタグではないか、またはテキスト系要素 (Text, Link, VText, RichText, Span) の終了タグであるとき、その行は無視される", () => {
+        it("Text内容の先頭で改行", () => {
+            const input = [
+                '<LinearLayout>',
+                '    <LayoutBody>',
+                '      <Text>',
+                'text</Text>', // ignore this line when detecting minimum indentation
+                '    </LayoutBody>',
+                '  </LinearLayout>'
+            ].join('\n');
+            const expected = [
+                '<LinearLayout>',
+                '  <LayoutBody>',
+                '    <Text>',
+                'text</Text>',
+                '  </LayoutBody>',
+                '</LinearLayout>'
+            ].join('\n');
+            expect(removeIndents(input)).toBe(expected);
+        });
+        it("Text内容の先頭で改行+インデント", () => {
+            const input = [
+                '<LinearLayout>',
+                '      <LayoutBody>',
+                '        <Text>',
+                '  text</Text>', // ignore this line when detecting minimum indentation, and keep this indent AS-IS
+                '      </LayoutBody>',
+                '    </LinearLayout>'
+            ].join('\n');
+            const expected = [
+                '<LinearLayout>',
+                '  <LayoutBody>',
+                '    <Text>',
+                '  text</Text>',
+                '  </LayoutBody>',
+                '</LinearLayout>'
+            ].join('\n');
+            expect(removeIndents(input)).toBe(expected);
+        });
+        it("Text内容の末尾で改行", () => {
+            const input = [
+                '<LinearLayout>',
+                '    <LayoutBody>',
+                '      <Text>text',
+                '</Text>', // ignore this line when detecting minimum indentation
+                '    </LayoutBody>',
+                '  </LinearLayout>'
+            ].join('\n');
+            const expected = [
+                '<LinearLayout>',
+                '  <LayoutBody>',
+                '    <Text>text',
+                '</Text>',
+                '  </LayoutBody>',
+                '</LinearLayout>'
+            ].join('\n');
+            expect(removeIndents(input)).toBe(expected);
+        });
+        it("Text内容の末尾で改行+インデント", () => {
+            const input = [
+                '<LinearLayout>',
+                '      <LayoutBody>',
+                '        <Text>text',
+                '  </Text>', // ignore this line when detecting minimum indentation, and keep this indent AS-IS
+                '      </LayoutBody>',
+                '    </LinearLayout>'
+            ].join('\n');
+            const expected = [
+                '<LinearLayout>',
+                '  <LayoutBody>',
+                '    <Text>text',
+                '  </Text>',
+                '  </LayoutBody>',
+                '</LinearLayout>'
+            ].join('\n');
+            expect(removeIndents(input)).toBe(expected);
+        });
+        it("先頭・末尾改行", () => {
+            const input = [
+                '<LinearLayout>',
+                '    <LayoutBody>',
+                '      <Text>',
+                'text', // ignore this line when detecting minimum indentation
+                '</Text>', // same here
+                '    </LayoutBody>',
+                '  </LinearLayout>'
+            ].join('\n');
+            const expected = [
+                '<LinearLayout>',
+                '  <LayoutBody>',
+                '    <Text>',
+                'text',
+                '</Text>',
+                '  </LayoutBody>',
+                '</LinearLayout>'
+            ].join('\n');
+            expect(removeIndents(input)).toBe(expected);
+        });
+        it("先頭・末尾改行+中身が複数行(インデントあり)", () => {
+            const input = [
+                '<LinearLayout>',
+                '    <LayoutBody>',
+                '      <Text>',
+                '  foo', // ignore this line when detecting minimum indentation, and keep this indent AS-IS
+                '  bar', // same here
+                '      </Text>', // same here
+                '    </LayoutBody>',
+                '  </LinearLayout>'
+            ].join('\n');
+            const expected = [
+                '<LinearLayout>',
+                '  <LayoutBody>',
+                '    <Text>',
+                '  foo',
+                '  bar',
+                '      </Text>',
+                '  </LayoutBody>',
+                '</LinearLayout>'
+            ].join('\n');
+            expect(removeIndents(input)).toBe(expected);
+        });
+
+        it("Link要素の終了タグは無視される", () => {
+            const input = [
+                '<LinearLayout>',
+                '    <LayoutBody>',
+                '      <Link>link text',
+                '</Link>', // ignore this line when detecting minimum indentation
+                '    </LayoutBody>',
+                '  </LinearLayout>'
+            ].join('\n');
+            const expected = [
+                '<LinearLayout>',
+                '  <LayoutBody>',
+                '    <Link>link text',
+                '</Link>',
+                '  </LayoutBody>',
+                '</LinearLayout>'
+            ].join('\n');
+            expect(removeIndents(input)).toBe(expected);
+        });
+
+        it("VText要素の終了タグは無視される", () => {
+            const input = [
+                '<LinearLayout>',
+                '    <LayoutBody>',
+                '      <VText>vertical text',
+                '</VText>', // ignore this line when detecting minimum indentation
+                '    </LayoutBody>',
+                '  </LinearLayout>'
+            ].join('\n');
+            const expected = [
+                '<LinearLayout>',
+                '  <LayoutBody>',
+                '    <VText>vertical text',
+                '</VText>',
+                '  </LayoutBody>',
+                '</LinearLayout>'
+            ].join('\n');
+            expect(removeIndents(input)).toBe(expected);
+        });
+
+        describe("RichText要素のmixed contentパターン", () => {
+            it("RichText内のテキストノードは無視される", () => {
+                const input = [
+                    '<LinearLayout>',
+                    '    <LayoutBody>',
+                    '      <RichText>',
+                    'plain text', // ignore this line when detecting minimum indentation
+                    '      </RichText>', // ignore this line when detecting minimum indentation, and keep this indent AS-IS
+                    '    </LayoutBody>',
+                    '  </LinearLayout>'
+                ].join('\n');
+                const expected = [
+                    '<LinearLayout>',
+                    '  <LayoutBody>',
+                    '    <RichText>',
+                    'plain text',
+                    '      </RichText>',
+                    '  </LayoutBody>',
+                    '</LinearLayout>'
+                ].join('\n');
+                expect(removeIndents(input)).toBe(expected);
+            });
+
+            it("RichText内のSpan要素の終了タグは無視される", () => {
+                const input = [
+                    '<LinearLayout>',
+                    '    <LayoutBody>',
+                    '      <RichText>text<Span>span text',
+                    '</Span>more text</RichText>', // ignore this line when detecting minimum indentation
+                    '    </LayoutBody>',
+                    '  </LinearLayout>'
+                ].join('\n');
+                const expected = [
+                    '<LinearLayout>',
+                    '  <LayoutBody>',
+                    '    <RichText>text<Span>span text',
+                    '</Span>more text</RichText>',
+                    '  </LayoutBody>',
+                    '</LinearLayout>'
+                ].join('\n');
+                expect(removeIndents(input)).toBe(expected);
+            });
+
+            it("RichText内の複雑なmixed content", () => {
+                const input = [
+                    '<LinearLayout>',
+                    '    <LayoutBody>',
+                    '      <RichText>',
+                    'start text', // ignore this line
+                    '        <Span>',
+                    'span text', // ignore this line
+                    '          <Span>nested span',
+                    '</Span>', // ignore this line
+                    'more span text', // ignore this line
+                    '        </Span>', // ignore this line
+                    'end text', // ignore this line
+                    '      </RichText>', // ignore this line
+                    '    </LayoutBody>',
+                    '  </LinearLayout>'
+                ].join('\n');
+                const expected = [
+                    '<LinearLayout>',
+                    '  <LayoutBody>',
+                    '    <RichText>',
+                    'start text',
+                    '      <Span>',
+                    'span text',
+                    '        <Span>nested span',
+                    '</Span>',
+                    'more span text',
+                    '        </Span>',
+                    'end text',
+                    '      </RichText>',
+                    '  </LayoutBody>',
+                    '</LinearLayout>'
+                ].join('\n');
+                expect(removeIndents(input)).toBe(expected);
+            });
+
+            it("RichText終了タグ単体も無視される", () => {
+                const input = [
+                    '<LinearLayout>',
+                    '    <LayoutBody>',
+                    '      <RichText>rich content',
+                    '</RichText>', // ignore this line when detecting minimum indentation
+                    '    </LayoutBody>',
+                    '  </LinearLayout>'
+                ].join('\n');
+                const expected = [
+                    '<LinearLayout>',
+                    '  <LayoutBody>',
+                    '    <RichText>rich content',
+                    '</RichText>',
+                    '  </LayoutBody>',
+                    '</LinearLayout>'
+                ].join('\n');
+                expect(removeIndents(input)).toBe(expected);
+            });
+        });
+
+        describe("Span要素のネストパターン", () => {
+            it("Span終了タグ単体は無視される", () => {
+                const input = [
+                    '<LinearLayout>',
+                    '    <LayoutBody>',
+                    '      <RichText><Span>content',
+                    '</Span></RichText>', // ignore this line when detecting minimum indentation
+                    '    </LayoutBody>',
+                    '  </LinearLayout>'
+                ].join('\n');
+                const expected = [
+                    '<LinearLayout>',
+                    '  <LayoutBody>',
+                    '    <RichText><Span>content',
+                    '</Span></RichText>',
+                    '  </LayoutBody>',
+                    '</LinearLayout>'
+                ].join('\n');
+                expect(removeIndents(input)).toBe(expected);
+            });
+
+            it("深くネストしたSpan要素", () => {
+                const input = [
+                    '<LinearLayout>',
+                    '    <LayoutBody>',
+                    '      <RichText>',
+                    'text1', // ignore this line
+                    '        <Span>',
+                    'text2', // ignore this line
+                    '          <Span>',
+                    'text3', // ignore this line
+                    '            <Span>deep content',
+                    '</Span>', // ignore this line
+                    'text4', // ignore this line
+                    '          </Span>', // ignore this line
+                    'text5', // ignore this line
+                    '        </Span>', // ignore this line
+                    'text6', // ignore this line
+                    '      </RichText>', // ignore this line
+                    '    </LayoutBody>',
+                    '  </LinearLayout>'
+                ].join('\n');
+                const expected = [
+                    '<LinearLayout>',
+                    '  <LayoutBody>',
+                    '    <RichText>',
+                    'text1',
+                    '      <Span>',
+                    'text2',
+                    '        <Span>',
+                    'text3',
+                    '          <Span>deep content',
+                    '</Span>',
+                    'text4',
+                    '          </Span>',
+                    'text5',
+                    '        </Span>',
+                    'text6',
+                    '      </RichText>',
+                    '  </LayoutBody>',
+                    '</LinearLayout>'
+                ].join('\n');
+                expect(removeIndents(input)).toBe(expected);
+            });
+
+            it("Span要素内でのテキストとSpanの組み合わせ", () => {
+                const input = [
+                    '<LinearLayout>',
+                    '    <LayoutBody>',
+                    '      <RichText>start<Span>before<Span>middle',
+                    '</Span>after</Span>end</RichText>', // ignore this line
+                    '    </LayoutBody>',
+                    '  </LinearLayout>'
+                ].join('\n');
+                const expected = [
+                    '<LinearLayout>',
+                    '  <LayoutBody>',
+                    '    <RichText>start<Span>before<Span>middle',
+                    '</Span>after</Span>end</RichText>',
+                    '  </LayoutBody>',
+                    '</LinearLayout>'
+                ].join('\n');
+                expect(removeIndents(input)).toBe(expected);
+            });
+
+            it("複数のSpan要素が並列に存在するパターン", () => {
+                const input = [
+                    '<LinearLayout>',
+                    '    <LayoutBody>',
+                    '      <RichText>',
+                    'start', // ignore this line
+                    '        <Span>first span',
+                    '</Span>', // ignore this line
+                    'middle', // ignore this line
+                    '        <Span>second span',
+                    '</Span>', // ignore this line
+                    'end', // ignore this line
+                    '      </RichText>', // ignore this line
+                    '    </LayoutBody>',
+                    '  </LinearLayout>'
+                ].join('\n');
+                const expected = [
+                    '<LinearLayout>',
+                    '  <LayoutBody>',
+                    '    <RichText>',
+                    'start',
+                    '      <Span>first span',
+                    '</Span>',
+                    'middle',
+                    '      <Span>second span',
+                    '</Span>',
+                    'end',
+                    '      </RichText>',
+                    '  </LayoutBody>',
+                    '</LinearLayout>'
+                ].join('\n');
+                expect(removeIndents(input)).toBe(expected);
+            });
+        });
+    });
+
+    it("全て空行や1行だけならそのまま返す", () => {
+        expect(removeIndents('')).toBe('');
+        expect(removeIndents('\n')).toBe('\n');
+        expect(removeIndents('<LinearLayout/>')).toBe('<LinearLayout/>');
+    });
+});

--- a/index.js
+++ b/index.js
@@ -21,7 +21,8 @@ import * as path from "path";
 import * as msgpack from "@msgpack/msgpack";
 import * as util from "util";
 import { yrtRootToPackage, packageToYrtRoot } from "./yrt_format.js";
-import { formatXml, isAlreadyMigrated, normalizeAssets } from "./utils.js";
+import { isAlreadyMigrated, normalizeAssets } from "./utils.js";
+import { formatXmlPretty, removeIndents } from "./formatter.mjs";
 import { migrate as layoutsToMultipleXmls } from "./multiple_xmls.mjs";
 import { migrate as removeContentElements } from "./remove_content_elements.mjs";
 import { migrate as styleElementMigrate } from "./style_element.mjs";
@@ -183,10 +184,10 @@ async function main() {
         }
 
         const migratedYrtRoot = migrate(inputYrtRoot);
-        // レイアウトXMLとStyle XMLを整形
-        migratedYrtRoot[2].l = migratedYrtRoot[2].l.map(([name, xml]) => [name, DO_FORMAT_XML ? formatXml(xml) : xml]);
+        // LayoutXMLとStyleXMLを整形（それぞれ別の関数を使用することに注意）
+        migratedYrtRoot[2].l = migratedYrtRoot[2].l.map(([name, xml]) => [name, DO_FORMAT_XML ? removeIndents(xml) : xml]);
         if (migratedYrtRoot[2].s) {
-            migratedYrtRoot[2].s = DO_FORMAT_XML ? formatXml(migratedYrtRoot[2].s) : migratedYrtRoot[2].s;
+            migratedYrtRoot[2].s = DO_FORMAT_XML ? formatXmlPretty(migratedYrtRoot[2].s) : migratedYrtRoot[2].s;
         }
         const migratedPkg = yrtRootToPackage(migratedYrtRoot);
         const outputFile = msgpack.encode(migratedYrtRoot);

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ import { migrate as borderAdjacentLineWarning } from "./border_adjacent_line_war
 import { migrate as warnSpanColorBinding } from "./span_color_binding_warn.mjs";
 import { migrate as applySchema } from "./apply_schema.mjs";
 
-// dry-run時のXML整形出力を制御
+// XML整形出力を制御
 const DO_FORMAT_XML = true;
 
 function migrate(newYrtRoot) {

--- a/utils.js
+++ b/utils.js
@@ -128,6 +128,7 @@ export function formatXml(xml) {
     // xml-formatter を使って2スペースインデントで整形
     return xmlFormat(xml, {
         indentation: "  ",
+        lineSeparator: "\n",
         whiteSpaceAtEndOfSelfclosingTag: true,
     });
 }

--- a/utils.js
+++ b/utils.js
@@ -126,5 +126,8 @@ export function getXPath(node) {
 
 export function formatXml(xml) {
     // xml-formatter を使って2スペースインデントで整形
-    return xmlFormat(xml, { indentation: "  " });
+    return xmlFormat(xml, {
+        indentation: "  ",
+        whiteSpaceAtEndOfSelfclosingTag: true,
+    });
 }

--- a/utils.js
+++ b/utils.js
@@ -1,5 +1,3 @@
-import xmlFormat from "xml-formatter";
-
 /**
  * 任意の値をUint8Arrayに変換する
  * @param {any} val
@@ -122,13 +120,4 @@ export function getXPath(node) {
         current = parent && parent.nodeType === 1 ? parent : null;
     }
     return path;
-}
-
-export function formatXml(xml) {
-    // xml-formatter を使って2スペースインデントで整形
-    return xmlFormat(xml, {
-        indentation: "  ",
-        lineSeparator: "\n",
-        whiteSpaceAtEndOfSelfclosingTag: true,
-    });
 }


### PR DESCRIPTION
### 変更点
- 新規モジュール `formatter.mjs` にて、インデント除去のみを行う新規関数 `removeIndents()` を実装
- LayoutXMLの整形には `removeIndents()` を使うよう変更
- StyleXMLの整形は従来通り xml-formatter の利用を継続。ただし関数を `utils.js` から `formatter.mjs` モジュールに移動して `formatXmlPretty()` にリネーム

### 備考
- `<GridStyle>` 等がStyleXMLに移動される際、当該箇所が空行のまま残るので少々かっこわるい

### 改善効果（例）

下記のXML(alpha.13)について、不要なインデントだけが除去されつつ、[PDF描画結果](https://github.com/user-attachments/files/21890710/sample.72.pdf)はマイグレート前後で全く同じになることを確認済み。

```
<LayoutXml>
  <LinearLayout>
    <LayoutBody>

      <Text size="8">leading whitespace ありの Text:</Text>
      <Text>    いろはにほへといろはにほへといろはにほへといろはにほへといろはにほへといろはにほへといろはにほへといろはにほへといろはにほへといろはにほへと</Text>

      <Spacer height="10" />

      <Text size="8">RichText + Span:</Text>
      <RichText><Span size="20">いろはにほへと</Span>いろはにほへといろはにほへといろはにほへといろはにほへといろはにほへといろはにほへといろはにほへといろはにほへといろはにほへといろはにほへといろはにほへと</RichText>

      <Spacer height="10" />

      <Text size="8">もともと改行ありの Text:</Text>
      <Text>
いろはにほへと</Text>
      <Text>いろはにほへと
  </Text>
      <Text>いろはにほへと
  ちりぬるを</Text>

    </LayoutBody>
  </LinearLayout>
</LayoutXml>
```